### PR TITLE
Migrate the OGC related services to the /ogc/ prefix

### DIFF
--- a/arlas-opensearch/src/main/java/io/arlas/server/rest/explore/opensearch/OpenSearchDescriptorService.java
+++ b/arlas-opensearch/src/main/java/io/arlas/server/rest/explore/opensearch/OpenSearchDescriptorService.java
@@ -68,7 +68,7 @@ public class OpenSearchDescriptorService extends ExploreRESTServices {
     public static final String MIME_TYPE_XML = "application/xml";
 
     @Timed
-    @Path("{collection}/_opensearch")
+    @Path("/ogc/opensearch/{collection}")
     @GET
     @Produces({MIME_TYPE_XML})
     @ApiOperation(value = "OpenSearch Description Document", produces = MIME_TYPE_XML, notes = Documentation.OPENSEARCH_OPERATION)

--- a/arlas-tests/src/test/java/io/arlas/server/ogc/wfs/WFSServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/ogc/wfs/WFSServiceIT.java
@@ -46,7 +46,7 @@ public class WFSServiceIT extends AbstractTestWithCollection {
 
     @Override
     protected String getUrlPath(String collection) {
-        return arlasPath + "wfs/" + collection;
+        return arlasPath + "ogc/wfs/" + collection;
     }
 
     @Test

--- a/docs/arlas-api-exploration.md
+++ b/docs/arlas-api-exploration.md
@@ -271,4 +271,4 @@ Fields can be provided several times by separating them with a comma. The order 
 
 ## OpenSearch
 
-If enabled, ARLAS offers an Opensearch Description document (`/arlas/explore/{collection}/_opensearch`).
+If enabled, ARLAS offers an Opensearch Description document (`/arlas/ogc/opensearch/{collection}`).

--- a/docs/arlas-api.md
+++ b/docs/arlas-api.md
@@ -6,7 +6,11 @@ The ARLAS Server offers 6 enpoints:
 - an exploration API for [exploring](arlas-api-exploration.md), meaning searching and analyzing, spatial-temoral big data (`http://.../arlas/explore/`)
 - a [tagging](arlas-api-tagging.md) service (`http://.../arlas/write/{collection}/_tag`)
 - a RATSER [tile service](arlas-tile-service.md) for rendering RASTER tiles based on the collection and on a tile service such as WMTS or X/Y/Z service
-- a WFS service (`http://.../arlas/wfs/{collection}?REQUEST=GetCapabilities&VERSION=2.0.0&SERVICE=WFS`)
+- OGC/opensearch services:
+    - a CSW service (`http://.../arlas/ogc/csw`)
+    - a CSW opensearch service (`http://.../arlas/ogc/csw/opensearch`)
+    - a WFS service (`http://.../arlas/ogc/wfs/{collection}?REQUEST=GetCapabilities&VERSION=2.0.0&SERVICE=WFS`)
+    - an opensearch service (`http://.../arlas/ogc/opensearch/{collection}`)
 - an API for monitoring the server health and performances
 - an endpoints for testing the collection API  and the exploration API with swagger
 

--- a/ogc-csw/src/main/java/io/arlas/server/ogc/csw/CSWService.java
+++ b/ogc-csw/src/main/java/io/arlas/server/ogc/csw/CSWService.java
@@ -66,8 +66,8 @@ import java.util.Optional;
 
 import static io.arlas.server.utils.CheckParams.isBboxLatLonInCorrectRanges;
 
-@Path("/collections")
-@Api(value = "/collections")
+@Path("/ogc")
+@Api(value = "/ogc")
 public class CSWService {
 
     protected CollectionReferenceDao dao = null;
@@ -313,7 +313,7 @@ public class CSWService {
             case GetCapabilities:
                 GetCapabilitiesHandler getCapabilitiesHandler = cswHandler.getCapabilitiesHandler;
                 JAXBElement<CapabilitiesType> getCapabilitiesResponse = getCapabilitiesHandler.getCSWCapabilitiesResponse(Arrays.asList(sectionList),
-                        serverUrl + "collections/csw/?", serverUrl + "collections/csw/_opensearch");
+                        serverUrl + "ogc/csw/?", serverUrl + "ogc/csw/opensearch");
                 return Response.ok(getCapabilitiesResponse).type(acceptFormatMediaType).build();
             case GetRecords:
                 GetRecordsHandler getRecordsHandler = cswHandler.getRecordsHandler;
@@ -341,7 +341,7 @@ public class CSWService {
     }
 
     @Timed
-    @Path("/csw/_opensearch")
+    @Path("/csw/opensearch")
     @GET
     @Produces({MediaType.APPLICATION_XML, MIME_TYPE__OPENSEARCH_XML})
     @ApiOperation(value = "OpenSearch CSW Description Document",

--- a/ogc-csw/src/main/java/io/arlas/server/ogc/csw/operation/opensearch/OpenSearchHandler.java
+++ b/ogc-csw/src/main/java/io/arlas/server/ogc/csw/operation/opensearch/OpenSearchHandler.java
@@ -44,7 +44,7 @@ public class OpenSearchHandler {
         description.setDescription(cswHandler.cswConfiguration.openSearchDescription);
         description.setShortName(cswHandler.cswConfiguration.openSearchShortName);
         Url urlXMLBox = new Url();
-        urlXMLBox.setTemplate(serverUrl + "collections/csw/?" + "request=GetRecords&service=CSW" +
+        urlXMLBox.setTemplate(serverUrl + "ogc/csw/?" + "request=GetRecords&service=CSW" +
                 "&version=3.0.0&q={searchTerms?}" +
                 "&startPosition={startIndex?}" +
                 "&maxRecords={count?}" +
@@ -53,7 +53,7 @@ public class OpenSearchHandler {
                 "&outputFormat=application/xml");
         urlXMLBox.setType(MediaType.APPLICATION_XML);
         Url urlATOMBox = new Url();
-        urlATOMBox.setTemplate(serverUrl + "collections/csw/?" + "request=GetRecords&service=CSW" +
+        urlATOMBox.setTemplate(serverUrl + "ogc/csw/?" + "request=GetRecords&service=CSW" +
                 "&version=3.0.0&q={searchTerms?}" +
                 "&startPosition={startIndex?}" +
                 "&maxRecords={count?}" +
@@ -62,7 +62,7 @@ public class OpenSearchHandler {
                 "&outputFormat=application/atom%2Bxml");
         urlATOMBox.setType(MediaType.APPLICATION_ATOM_XML);
         Url urlXMLId = new Url();
-        urlXMLId.setTemplate(serverUrl + "collections/csw/?" + "request=GetRecords&service=CSW" +
+        urlXMLId.setTemplate(serverUrl + "ogc/csw/?" + "request=GetRecords&service=CSW" +
                 "&version=3.0.0" +
                 "&startPosition={startIndex?}" +
                 "&maxRecords={count?}" +
@@ -71,7 +71,7 @@ public class OpenSearchHandler {
                 "&outputFormat=application/xml");
         urlXMLId.setType(MediaType.APPLICATION_XML);
         Url urlATOMId = new Url();
-        urlATOMId.setTemplate(serverUrl + "collections/csw/?" + "request=GetRecords&service=CSW" +
+        urlATOMId.setTemplate(serverUrl + "ogc/csw/?" + "request=GetRecords&service=CSW" +
                 "&version=3.0.0" +
                 "&startPosition={startIndex?}" +
                 "&maxRecords={count?}" +

--- a/ogc-csw/src/main/java/io/arlas/server/ogc/csw/writer/getrecords/AtomGetRecordsMessageBodyWriter.java
+++ b/ogc-csw/src/main/java/io/arlas/server/ogc/csw/writer/getrecords/AtomGetRecordsMessageBodyWriter.java
@@ -102,7 +102,7 @@ public class AtomGetRecordsMessageBodyWriter implements MessageBodyWriter<GetRec
         }
         LinkType linkType = new LinkType();
         linkType.setType(CSWService.MIME_TYPE__OPENSEARCH_XML);
-        linkType.setHref(arlasServerConfiguration.ogcConfiguration.serverUri + "collections/csw/_opensearch");
+        linkType.setHref(arlasServerConfiguration.ogcConfiguration.serverUri + "ogc/opensearch/{collection}");
         linkType.setRel("search");
         feedType.getLink().add(linkType);
         com.a9.opensearch.ObjectFactory openSearchFactory = new com.a9.opensearch.ObjectFactory();

--- a/ogc-wfs/src/main/java/io/arlas/server/ogc/wfs/WFSService.java
+++ b/ogc-wfs/src/main/java/io/arlas/server/ogc/wfs/WFSService.java
@@ -61,8 +61,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
-@Path("/wfs")
-@Api(value = "/wfs")
+@Path("/ogc/wfs")
+@Api(value = "/ogc/wfs")
 public class WFSService {
     Logger LOGGER = LoggerFactory.getLogger(WFSService.class);
 
@@ -202,7 +202,7 @@ public class WFSService {
         // TODO add cache in describeCollection method
         CollectionReferenceDescription collectionReferenceDescription = elasticAdmin.describeCollection(collectionReference);
         String collectionName = collectionReferenceDescription.collectionName;
-        String serviceUrl = serverUrl + "wfs/" + collectionName + "/?";
+        String serviceUrl = serverUrl + "ogc/wfs/" + collectionName + "/?";
         QName featureQname = new QName(serviceUrl, collectionName, wfsConfiguration.featureNamespace);
         WFSCheckParam.checkTypeNames(collectionName, typenames);
         WFSQueryBuilder wfsQueryBuilder = new WFSQueryBuilder(requestType, id, bbox, filter, resourceid, storedquery_id, collectionReferenceDescription, partitionFilter, exploreServices);

--- a/scripts/tests-integration-stage.sh
+++ b/scripts/tests-integration-stage.sh
@@ -107,7 +107,7 @@ function test_wfs() {
     docker run --rm \
          --net arlas_default \
          --env ID="ID__170__20DI"\
-         --env WFS_GETCAPABILITIES_URL="http://arlas-server:9999/pathtest/arlastest/wfs/geodata/?request=GetCapabilities&service=WFS&version=2.0.0" \
+         --env WFS_GETCAPABILITIES_URL="http://arlas-server:9999/pathtest/arlastest/ogc/wfs/geodata/?request=GetCapabilities&service=WFS&version=2.0.0" \
          gisaia/ets-wfs20
 
     docker run --rm \
@@ -148,7 +148,7 @@ function test_csw() {
 
     docker run --rm \
          --net arlas_default \
-         --env CSW_GETCAPABILITIES_URL="http://arlas-server:9999/pathtest/arlastest/collections/csw/?" \
+         --env CSW_GETCAPABILITIES_URL="http://arlas-server:9999/pathtest/arlastest/ogc/csw/?" \
          gisaia/ets-cat30
 
     docker run --rm \


### PR DESCRIPTION
- /arlas/explore/{collection}/_opensearch moves to /arlas/ogc/opensearch/{collection}
- /arlas/wfs/{collection} moves to /arlas/ogc/wfs/{collection}
- /arlas/collections/csw moves to /arlas/ogc/csw/
- /arlas/collections/csw/_opensearch moves to /arlas/ogc/csw/opensearch