### PR TITLE
Remove centroid/geometry from _geosearch response when falt=true

### DIFF
--- a/arlas-tests/src/test/java/io/arlas/server/rest/explore/AbstractProjectedTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/rest/explore/AbstractProjectedTest.java
@@ -63,11 +63,11 @@ public abstract class AbstractProjectedTest extends AbstractSizedTest {
 
         search.projection.excludes = "params.job,fullname";
         search.projection.includes = "geo_params.geometry";
-        handleDisplayedParameter(post(search), Arrays.asList("id", "params.startdate", "geo_params.geometry", "geo_params.centroid"));
+        handleDisplayedParameter(post(search), Arrays.asList("id", "params.startdate",  "geo_params.centroid"));
         handleDisplayedParameter(givenFilterableRequestParams().param("include", search.projection.includes)
                 .param("exclude", search.projection.excludes)
                 .when().get(getUrlPath("geodata"))
-                .then(), Arrays.asList("id", "params.startdate", "geo_params.geometry", "geo_params.centroid"));
+                .then(), Arrays.asList("id", "params.startdate",  "geo_params.centroid"));
 
         search.projection.includes = null;
         search.projection.excludes = null;

--- a/arlas-tests/src/test/java/io/arlas/server/utils/MapExplorerTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/utils/MapExplorerTest.java
@@ -22,10 +22,13 @@ package io.arlas.server.utils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.core.IsNot;
 import org.junit.Assert;
 import org.junit.Test;
+import org.opengis.filter.Not;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 public class MapExplorerTest {
@@ -35,7 +38,7 @@ public class MapExplorerTest {
         Map<String, Object> flat =
                 MapExplorer.flat(
                         new ObjectMapper().reader(new TypeReference<Map<String, Object>>(){}).readValue(this.getClass().getClassLoader().getResourceAsStream("flatMapTest.json")),
-                        new MapExplorer.ReduceArrayOnKey("_"));
+                        new MapExplorer.ReduceArrayOnKey("_"), Collections.singleton("a.e.g.2"));
         Assert.assertThat(flat,IsMapContaining.hasEntry("a_b_0_c", 1));
         Assert.assertThat(flat,IsMapContaining.hasEntry("a_b_1_c", 2));
         Assert.assertThat(flat,IsMapContaining.hasEntry("a_b_2_d", "a"));
@@ -43,6 +46,6 @@ public class MapExplorerTest {
         Assert.assertThat(flat,IsMapContaining.hasEntry("a_e_f", "a"));
         Assert.assertThat(flat,IsMapContaining.hasEntry("a_e_g_0", 1));
         Assert.assertThat(flat,IsMapContaining.hasEntry("a_e_g_1", 2));
-        Assert.assertThat(flat,IsMapContaining.hasEntry("a_e_g_2", 3));
+        Assert.assertThat(flat,IsNot.not(IsMapContaining.hasEntry("a_e_g_2", 3)));
     }
 }


### PR DESCRIPTION
- On the _geosearch, when the property map is requested flat, then the geometry must not be included