### PR TITLE
Remove 'elastic-host' and 'elastic-port' from Arlas configuration

### DIFF
--- a/arlas-core/src/main/java/io/arlas/server/app/ArlasServerConfiguration.java
+++ b/arlas-core/src/main/java/io/arlas/server/app/ArlasServerConfiguration.java
@@ -62,12 +62,6 @@ public class ArlasServerConfiguration extends Configuration {
     @JsonProperty("elastic-nodes")
     public String elasticnodes;
 
-    @JsonProperty("elastic-host")
-    public String elastichost;
-
-    @JsonProperty("elastic-port")
-    public Integer elasticport;
-
     @JsonProperty("elastic-sniffing")
     public Boolean elasticsniffing;
 
@@ -131,8 +125,6 @@ public class ArlasServerConfiguration extends Configuration {
         List<Pair<String,Integer>> elasticNodes = new ArrayList<>();
         if(!StringUtil.isNullOrEmpty(elasticnodes)) {
             elasticNodes.addAll(getElasticNodes(elasticnodes));
-        } else if(!StringUtil.isNullOrEmpty(elastichost) && elasticport > 0) {
-            elasticNodes.add(new ImmutablePair<>(elastichost, elasticport));
         }
         return elasticNodes;
     }

--- a/conf/configuration.yaml
+++ b/conf/configuration.yaml
@@ -61,9 +61,7 @@ logging:
 ############ DATASOURCE                  ###############
 ########################################################
 # Configuration of the datasource
-elastic-nodes: ${ARLAS_ELASTIC_NODES:-}
-elastic-host: ${ARLAS_ELASTIC_HOST:-localhost}
-elastic-port: ${ARLAS_ELASTIC_PORT:-9300}
+elastic-nodes: ${ARLAS_ELASTIC_NODES:-localhost:9300}
 elastic-sniffing: ${ARLAS_ELASTIC_SNIFFING:-false}
 elastic-cluster: ${ARLAS_ELASTIC_CLUSTER:-elasticsearch}
 arlas-index:  ${ARLAS_ELASTIC_INDEX:-.arlas}

--- a/docs/arlas-server-configuration.md
+++ b/docs/arlas-server-configuration.md
@@ -79,14 +79,16 @@ docker run -ti -d \
 | Environment variable   | ARLAS Server configuration variable | Default | Description |
 | --- | --- | --- | ---  |
 | ARLAS_ELASTIC_NODES    | elastic-nodes    | localhost:9300 | coma separated list of elasticsearch nodes as host:port values |
-| ARLAS_ELASTIC_HOST     | elastic-host     | localhost      | (DEPRECATED) hostname or ip address of the elasticsearch node that is used for storing ARLAS configuration |
-| ARLAS_ELASTIC_PORT     | elastic-port     | 9300           | (DEPRECATED) port of the elasticsearch node that is used for storing ARLAS configuration  |
 | ARLAS_ELASTIC_SNIFFING | elastic-sniffing | false          | allow elasticsearch to dynamically add new hosts and remove old ones (*)|
 | ARLAS_ELASTIC_CLUSTER  | elastic-cluster  | elasticsearch  | clustername of the elasticsearch cluster that is used for storing ARLAS configuration |
 | ARLAS_ELASTIC_INDEX    | arlas-index      | .arlas         | name of the index that is used for storing ARLAS configuration |
 
-(*) Note that the IP addresses the sniffer connects to are the ones declared as the publish address in those node’s Elasticsearch config.
+!!! note 
+    (*) Note that the IP addresses the sniffer connects to are the ones declared as the publish address in those node’s Elasticsearch config.
 
+!!! info "Important" 
+    `elastic-host` and `elastic-port` configuration variables do not longer exist in 10.6.0. You can use `elastic-nodes` instead.
+    
 ### Collection Cache & Disovery
 
 | Environment variable | ARLAS Server configuration variable | Default | Description |


### PR DESCRIPTION
Fix #254