### PR TITLE
Remove 'link.next' from _search response when reaching the last page

### DIFF
--- a/arlas-core/src/main/java/io/arlas/server/core/FluidSearch.java
+++ b/arlas-core/src/main/java/io/arlas/server/core/FluidSearch.java
@@ -80,7 +80,7 @@ public class FluidSearch {
     public static final String INVALID_WKT = "Invalid WKT geometry.";
     public static final String INVALID_WKT_RANGE = "Invalid WKT geometry.Coordinate out of range";
     public static final String INVALID_BBOX = "Invalid BBOX";
-    public static final String INVALID_SIZE = "Invalid size parameter.";
+    public static final String INVALID_SIZE = "Invalid size parameter. It should be a strictly positive integer";
     public static final String INVALID_FROM = "Invalid from parameter: should be a positive integer.";
     public static final String INVALID_DATE_UNIT = "Invalid date unit.";
     public static final String INVALID_GEOSORT_LAT_LON = "'lat lon' must be numeric values separated by a space";

--- a/arlas-core/src/main/java/io/arlas/server/services/ExploreServices.java
+++ b/arlas-core/src/main/java/io/arlas/server/services/ExploreServices.java
@@ -61,6 +61,10 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class ExploreServices {
+
+    public static final Integer SEARCH_DEFAULT_PAGE_SIZE = 10;
+    public static final Integer SEARCH_DEFAULT_PAGE_FROM = 0;
+
     private Client client;
     private CollectionReferenceDao daoCollectionReference;
     private ResponseCacheManager responseCacheManager = null;
@@ -225,11 +229,15 @@ public class ExploreServices {
 
     protected void setPageSizeAndFrom(Page page, FluidSearch fluidSearch) throws ArlasException {
         if (page != null) {
+            if (page.size == null) {
+                page.size = SEARCH_DEFAULT_PAGE_SIZE;
+            }
+            if (page.from == null) {
+                page.from = SEARCH_DEFAULT_PAGE_FROM;
+            }
             CheckParams.checkPageSize(page);
             CheckParams.checkPageFrom(page);
-            if (page.size != null && page.from != null) {
-                fluidSearch = fluidSearch.filterSize(page.size, page.from);
-            }
+            fluidSearch = fluidSearch.filterSize(page.size, page.from);
         }
     }
 

--- a/arlas-core/src/main/java/io/arlas/server/utils/CheckParams.java
+++ b/arlas-core/src/main/java/io/arlas/server/utils/CheckParams.java
@@ -244,10 +244,7 @@ public class CheckParams {
 
     public static void checkPageSize(Page page) throws ArlasException {
         if (page != null) {
-            if (page.size == null) {
-                //Default Value
-                page.size = 10;
-            } else if (page.size <= 0){
+            if (page.size == null || page.size <= 0){
                 throw new InvalidParameterException(FluidSearch.INVALID_SIZE);
             }
         }
@@ -255,10 +252,7 @@ public class CheckParams {
 
     public static void checkPageFrom(Page page) throws ArlasException {
         if (page != null) {
-            if (page.from == null) {
-                //Default Value
-                page.from = 0;
-            } else if (page.from < 0) {
+            if (page.from == null || page.from < 0) {
                 throw new InvalidParameterException(FluidSearch.INVALID_FROM);
             }
         }


### PR DESCRIPTION
Fix #436 