### PR TITLE
Add `arlas-base-uri` config variable used to configure 'link' of a search response

### DIFF
--- a/arlas-core/src/main/java/io/arlas/server/app/ArlasServerConfiguration.java
+++ b/arlas-core/src/main/java/io/arlas/server/app/ArlasServerConfiguration.java
@@ -28,6 +28,8 @@ import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -37,6 +39,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ArlasServerConfiguration extends Configuration {
+
+    protected static Logger LOGGER = LoggerFactory.getLogger(ArlasServerConfiguration.class);
 
     @JsonProperty("arlas-wfs")
     public WFSConfiguration wfsConfiguration;
@@ -70,6 +74,9 @@ public class ArlasServerConfiguration extends Configuration {
 
     @JsonProperty("arlas-index")
     public String arlasindex;
+
+    @JsonProperty("arlas-base-uri")
+    public String arlasBaseUri;
 
     @JsonProperty("arlas-cache-size")
     public int arlascachesize;
@@ -140,6 +147,14 @@ public class ArlasServerConfiguration extends Configuration {
         }
         if (swaggerBundleConfiguration == null) {
             throw new ArlasConfigurationException("Swagger configuration missing in config file.");
+        }
+        LOGGER.info("========>   arlasBaseUri : " + arlasBaseUri);
+        if (arlasBaseUri != null) {
+            try {
+                URI uri = new URI(arlasBaseUri);
+            } catch (URISyntaxException e) {
+                throw new ArlasConfigurationException("The arlas-base-uri is invalid.");
+            }
         }
         if (opensearchConfiguration != null && opensearchConfiguration.urlTemplatePrefix != null) {
             try {

--- a/arlas-core/src/main/java/io/arlas/server/services/ExploreServices.java
+++ b/arlas-core/src/main/java/io/arlas/server/services/ExploreServices.java
@@ -68,11 +68,21 @@ public class ExploreServices {
     private Client client;
     private CollectionReferenceDao daoCollectionReference;
     private ResponseCacheManager responseCacheManager = null;
+    private ArlasServerConfiguration configuration;
 
     public ExploreServices(Client client, ArlasServerConfiguration configuration) {
         this.client = client;
+        this.configuration = configuration;
         this.daoCollectionReference = new ElasticCollectionReferenceDaoImpl(client, configuration.arlasindex, configuration.arlascachesize, configuration.arlascachetimeout);
         this.responseCacheManager = new ResponseCacheManager(configuration.arlasrestcachetimeout);
+    }
+
+    public String getBaseUri() {
+        String baseUri = null;
+        if (configuration.arlasBaseUri != null) {
+            baseUri =  configuration.arlasBaseUri;
+        }
+        return baseUri;
     }
 
     public Client getClient() {

--- a/arlas-rest/src/main/java/io/arlas/server/rest/explore/ExploreRESTServices.java
+++ b/arlas-rest/src/main/java/io/arlas/server/rest/explore/ExploreRESTServices.java
@@ -59,4 +59,8 @@ public abstract class ExploreRESTServices {
     public Response cache(Response.ResponseBuilder response, Integer maxagecache) {
         return exploreServices.getResponseCacheManager().cache(response, maxagecache);
     }
+
+    public String getExplorePathUri() {
+        return "explore/";
+    }
 }

--- a/conf/configuration.yaml
+++ b/conf/configuration.yaml
@@ -42,6 +42,11 @@ server:
   maxQueuedRequests: ${ARLAS_MAX_QUEUED_REQUESTS:-1024}
 
 ########################################################
+############ URL Masking                 ###############
+########################################################
+arlas-base-uri: ${ARLAS_BASE_URI:-}
+
+########################################################
 ############ LOGGING                     ###############
 ########################################################
 # Configuration console and file LOGGING
@@ -98,7 +103,7 @@ zipkin: # The ZIPIN configuration, not active by default
   baseUrl: ${ARLAS_ZIPKIN_BASEURL:-http://localhost:9411} # Where is zipkin running?
 
 ########################################################
-############ WFS                      ###############
+############ WFS                         ###############
 ########################################################
 arlas-wfs:
   featureNamespace: ${ARLAS_WFS_FEATURE_NAMESPACE:-arlas}

--- a/docs/arlas-server-configuration.md
+++ b/docs/arlas-server-configuration.md
@@ -116,11 +116,17 @@ docker run -ti -d \
 | ARLAS_MIN_THREADS | server.minThreads | 8 |
 | ARLAS_MAX_QUEUED_REQUESTS | server.maxQueuedRequests | 1024 |
 
+### URL Masking
+
+| Environment variable | ARLAS Server configuration variable | Default | Description |
+| --- | --- | --- | --- |
+| ARLAS_BASE_URI   | arlas-base-uri | `None` | Base URI to ARLAS Server. If not set, the real base URI is exposed |
+
 ### OGC
 
 | Environment variable | ARLAS OGC Server configuration variable | Default | Description |
 | --- | --- | --- | --- |
-| ARLAS_OGC_SERVER_URI | arlas-ogc.serverUri | http://localhost:9999/arlas/ | URI to ARLAS Server |
+| ARLAS_OGC_SERVER_URI | arlas-ogc.serverUri | http://localhost:9999/arlas/ | Base URI to ARLAS Server |
 | ARLAS_OGC_SERVICE_PROVIDER_NAME | arlas-ogc.serviceProviderName | OrganisationName | Name of the organization responsible for the establishment, management, maintenance and distribution of the WFS & CSW services |
 | ARLAS_OGC_SERVICE_PROVIDER_SITE | arlas-ogc.serviceProviderSite | OrganisationWebSite | A link to the site of the WFS & CSW service provider |
 | ARLAS_OGC_SERVICE_PROVIDER_ROLE | arlas-ogc.serviceProviderRole | pointOfContact | Function performed by the party responsible for the WFS & CSW services |
@@ -130,8 +136,7 @@ docker run -ti -d \
 | ARLAS_OGC_SERVICE_CONTACT_CODE | arlas-ogc.serviceContactAdressPostalCode | 31000 | Postal code of the organization responsible for WFS & CSW services |
 | ARLAS_OGC_SERVICE_CONTACT_COUNTRY | arlas-ogc.serviceContactAdressCountry | France | Country of the organization responsible for WFS & CSW services |
 | ARLAS_OGC_QUERYMAXFEATURE | arlas-ogc.queryMaxFeature | 1000 | Maximum number of features returned by OGC queries |
-
-
+    
 ### WFS
 
 | Environment variable | ARLAS WFS Server configuration variable | Default | Description |
@@ -163,8 +168,9 @@ docker run -ti -d \
 | --- | --- | --- |
 | ARLAS_OPENSEARCH_URL_TEMPLATE | opensearch.url-template-prefix | http://localhost:9999/arlas/explore/COLLECTION/_search |
 
-> Note :  If the placemark COLLECTION is specified in the url template, then it will be replaced by the collection name by ARLAS server.
-
+!!! note "Note"
+    If the placemark `COLLECTION` is specified in the url template, then it will be replaced by the collection name by ARLAS server.
+    
 ### Logging
 
 | Environment variable | ARLAS Server configuration variable | Default |


### PR DESCRIPTION
Fix #437 
Fix #451 