### PR TITLE
Deprecate [opensearch.url-template-prefix]. [arlas-base-uri] is used instead

### DIFF
--- a/arlas-core/src/main/java/io/arlas/server/app/ArlasServerConfiguration.java
+++ b/arlas-core/src/main/java/io/arlas/server/app/ArlasServerConfiguration.java
@@ -40,8 +40,6 @@ import java.util.List;
 
 public class ArlasServerConfiguration extends Configuration {
 
-    protected static Logger LOGGER = LoggerFactory.getLogger(ArlasServerConfiguration.class);
-
     @JsonProperty("arlas-wfs")
     public WFSConfiguration wfsConfiguration;
 
@@ -148,7 +146,6 @@ public class ArlasServerConfiguration extends Configuration {
         if (swaggerBundleConfiguration == null) {
             throw new ArlasConfigurationException("Swagger configuration missing in config file.");
         }
-        LOGGER.info("========>   arlasBaseUri : " + arlasBaseUri);
         if (arlasBaseUri != null) {
             try {
                 URI uri = new URI(arlasBaseUri);

--- a/arlas-opensearch/src/main/java/io/arlas/server/rest/explore/opensearch/OpenSearchDescriptorService.java
+++ b/arlas-opensearch/src/main/java/io/arlas/server/rest/explore/opensearch/OpenSearchDescriptorService.java
@@ -102,9 +102,13 @@ public class OpenSearchDescriptorService extends ExploreRESTServices {
         //[scheme:][//authority][path][?query][#fragment]
         if (cr.params.openSearch != null) {
             OpenSearch os = cr.params.openSearch;
-            if (opensearchConfiguration != null && opensearchConfiguration.urlTemplatePrefix != null) {
+            String baseUri = this.getExploreServices().getBaseUri();
+            if (!StringUtil.isNullOrEmpty(baseUri)) {
+                prefix = this.getExploreServices().getBaseUri() + this.getExplorePathUri() + collection + "/_search";
+            } else  if (opensearchConfiguration != null && opensearchConfiguration.urlTemplatePrefix != null) {
                 prefix = opensearchConfiguration.urlTemplatePrefix;
                 prefix = prefix.replace(OpensearchConfiguration.COLLECTION_PLACEMARK, collection);
+                LOGGER.warn("[opensearch.url-template-prefix] is deprecated. Use [arlas-base-uri] instead.");
             }
             description.adultContent = os.adultContent;
             description.attribution = os.attribution;

--- a/docs/arlas-server-configuration.md
+++ b/docs/arlas-server-configuration.md
@@ -171,6 +171,9 @@ docker run -ti -d \
 !!! note "Note"
     If the placemark `COLLECTION` is specified in the url template, then it will be replaced by the collection name by ARLAS server.
     
+!!! info "Important"
+    `ARLAS_OPENSEARCH_URL_TEMPLATE` is deprecated starting from v10.6.1. It's recommended to use `ARLAS_BASE_URI` instead. `ARLAS_OPENSEARCH_URL_TEMPLATE` is taken into account only if `ARLAS_BASE_URI` is not specified.
+
 ### Logging
 
 | Environment variable | ARLAS Server configuration variable | Default |


### PR DESCRIPTION
Fix #453 