### PR TITLE
Fix/column filter match within

### DIFF
--- a/arlas-core/src/main/java/io/arlas/server/utils/FilterMatcherUtil.java
+++ b/arlas-core/src/main/java/io/arlas/server/utils/FilterMatcherUtil.java
@@ -67,9 +67,10 @@ public class FilterMatcherUtil {
      * Checking paths `params` and `params.city`, this will return `true` for both if `params.city` belongs to predicates
      * @param predicates
      * @param path
+     * @param checkWithin
      * @return
      */
-    public static boolean matchesOrWithin(Optional<Set<String>> predicates, String path) {
+    public static boolean matchesOrWithin(Optional<Set<String>> predicates, String path, boolean checkWithin) {
         if (StringUtils.isBlank(path)) {
             return false;
         }
@@ -77,7 +78,7 @@ public class FilterMatcherUtil {
         return predicates.map(
                 cf -> cf.stream().anyMatch(c ->
                         //for fields: test if match. For parent path: also test if a filter starts with path
-                        c.startsWith(path + "\\.") || addOrGetFromCache(c).matcher(path).matches()))
+                        addOrGetFromCache(c).matcher(path).matches() || checkWithin && c.startsWith(path + "\\.")))
                 //default if filter isn't present: allow
                 .orElse(true);
     }

--- a/arlas-tests/src/test/java/io/arlas/server/rest/explore/AbstractDescribeTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/rest/explore/AbstractDescribeTest.java
@@ -71,6 +71,9 @@ public abstract class AbstractDescribeTest extends AbstractTestWithCollection {
         handleNotMatchingResponse(get(Optional.of("*.*")), new JsonPath(this.getClass().getClassLoader().getResourceAsStream(getDescribeResultPath())));
         handleMatchingResponse(get(Optional.of("fullname,*.*")), new JsonPath(this.getClass().getClassLoader().getResourceAsStream(getDescribeResultPath())));
         handleNotMatchingResponse(get(Optional.of("fullname,params.")), new JsonPath(this.getClass().getClassLoader().getResourceAsStream(getDescribeResultPath())));
+
+        //anti regression - this used to work
+        handleNotMatchingResponse(get(Optional.of("fullname.unknown,params,,geo_params.wktgeomet")), new JsonPath(this.getClass().getClassLoader().getResourceAsStream(getFilteredDescribeResultPath())));
     }
 
     /**

--- a/ogc-common/src/main/java/io/arlas/server/ogc/common/utils/XmlUtils.java
+++ b/ogc-common/src/main/java/io/arlas/server/ogc/common/utils/XmlUtils.java
@@ -55,7 +55,7 @@ public class XmlUtils {
             namespace.push(key);
             String path = String.join(".", new ArrayList<>(namespace));
             boolean excludePath = excludeFields.stream().anyMatch(pattern -> pattern.matcher(path).matches());
-            boolean isAllowed = FilterMatcherUtil.matchesOrWithin(columnFilterPredicates, path);
+            boolean isAllowed = FilterMatcherUtil.matchesOrWithin(columnFilterPredicates, path, property.type == ElasticType.OBJECT);
             if (!excludePath && isAllowed) {
                 if (property.type == ElasticType.OBJECT) {
                     parsePropertiesXsd(property.properties, writer, namespace, excludeFields, columnFilterPredicates);


### PR DESCRIPTION
Fix security issue

A column filter with "field.any" used to be
valid in a "describe" to allow "field"