### PR TITLE
Including only unknown columns returns mandatory cols.

### DIFF
--- a/arlas-core/src/main/java/io/arlas/server/services/ExploreServices.java
+++ b/arlas-core/src/main/java/io/arlas/server/services/ExploreServices.java
@@ -300,7 +300,10 @@ public class ExploreServices {
 
     protected void applyProjection(Projection projection, FluidSearch fluidSearch, Optional<String> columnFilter, CollectionReference collectionReference) {
         if (ColumnFilterUtil.isValidColumnFilterPresent(columnFilter)) {
-            String filteredIncludes = ColumnFilterUtil.getFilteredIncludes(columnFilter, projection, elasticAdmin.getCollectionFields(collectionReference, columnFilter));
+            String filteredIncludes = ColumnFilterUtil.getFilteredIncludes(columnFilter, projection, elasticAdmin.getCollectionFields(collectionReference, columnFilter))
+                    .orElse(
+                            // if filteredIncludes were to be null or an empty string, FluidSearch would then build a bad request
+                            fluidSearch.getCollectionPaths().stream().collect(Collectors.joining(",")));
             fluidSearch = fluidSearch.include(filteredIncludes);
 
         } else if (projection != null && !Strings.isNullOrEmpty(projection.includes)) {

--- a/arlas-core/src/main/java/io/arlas/server/utils/ColumnFilterUtil.java
+++ b/arlas-core/src/main/java/io/arlas/server/utils/ColumnFilterUtil.java
@@ -135,10 +135,10 @@ public class ColumnFilterUtil {
         }
     }
 
-    public static String getFilteredIncludes(Optional<String> columnFilter, Projection projection, Set<String> allowedFields) {
+    public static Optional<String> getFilteredIncludes(Optional<String> columnFilter, Projection projection, Set<String> allowedFields) {
 
         if (projection == null || StringUtils.isBlank(projection.includes)) {
-            return columnFilter.get();
+            return Optional.ofNullable(columnFilter.get());
         }
 
         Optional<Set<String>> includesPredicates = FilterMatcherUtil.filterToPredicatesAsSet(Optional.of(projection.includes));
@@ -146,7 +146,7 @@ public class ColumnFilterUtil {
         return allowedFields.stream()
                 .filter(
                         f -> FilterMatcherUtil.matches(includesPredicates, f))
-                .collect(Collectors.joining(","));
+                .reduce((left, right) -> left + "," + right);
     }
 
     /**

--- a/arlas-tests/src/test/java/io/arlas/server/rest/explore/AbstractProjectedTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/rest/explore/AbstractProjectedTest.java
@@ -95,10 +95,13 @@ public abstract class AbstractProjectedTest extends AbstractPaginatedTest {
         handleHiddenParameter(post(search, "params"), Arrays.asList("fullname"));
         handleHiddenParameter(get("include", search.projection.includes, "params"), Arrays.asList("fullname"));
 
-        //unexisting column should not break if used in includes and filter, it is simply not returned
+        //unexisting column should not break if used in includes and filter, it is simply not returned.
+        // Only mandatory columns should be returned with no existing columns at all in the filter
         search.projection.includes = "unexisting";
-        handleHiddenParameter(post(search, "unexisting"), Arrays.asList("unexisting"));
-        handleHiddenParameter(get("unexisting", search.projection.includes, "params"), Arrays.asList("unexisting"));
+        handleHiddenParameter(post(search, "unexisting"), Arrays.asList("unexisting", "params.job"));
+        handleHiddenParameter(get("include", search.projection.includes, "unexisting"), Arrays.asList("unexisting", "params.job"));
+        handleDisplayedParameter(post(search, "unexisting"), Arrays.asList("params.startdate", "id", "geo_params.centroid"));
+        handleDisplayedParameter(get("include", search.projection.includes, "unexisting"), Arrays.asList("params.startdate", "id", "geo_params.centroid"));
 
         //include without wildcard can be used if a filter matches
         search.projection.includes = "id,params";
@@ -108,6 +111,9 @@ public abstract class AbstractProjectedTest extends AbstractPaginatedTest {
         handleDisplayedParameter(post(search, "id,params*"), Arrays.asList("params.country"));
         handleDisplayedParameter(get("include", search.projection.includes, "id,params*"), Arrays.asList("params.country"));
 
+        //not included columns should not be present
+        handleHiddenParameter(post(search, "params,fullname"), Arrays.asList("fullname"));
+        handleHiddenParameter(get("include", search.projection.includes, "params,fullname"), Arrays.asList("fullname"));
 
         search.projection.excludes = "params.job,fullname";
         search.projection.includes = "geo_params.geometry";


### PR DESCRIPTION
It used to return all columns.