### PR TITLE
Google Storage build requirements

### DIFF
--- a/docker-compose-elasticsearch.yml
+++ b/docker-compose-elasticsearch.yml
@@ -5,9 +5,9 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.6.0}
     container_name: elasticsearch
     environment:
+      - discovery.type=single-node
       - cluster.name=docker-cluster
       - node.name=docker-node
-      - cluster.initial_master_nodes=docker-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - xpack.security.enabled=false
       - xpack.monitoring.enabled=false
@@ -18,4 +18,3 @@ services:
       - ${ELASTIC_DATADIR}:/usr/share/elasticsearch/data
     ports:
       - 19200:9200
-      - 19300:9300

--- a/docker-compose-network.yml
+++ b/docker-compose-network.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+networks:
+  default:
+    external:
+      name: cloudbuild

--- a/docs/arlas-server-configuration.md
+++ b/docs/arlas-server-configuration.md
@@ -73,7 +73,7 @@ docker run -ti -d \
 ### CORS, HEADERS for API response
 
 | Environment variable | ARLAS Server configuration variable | Default | Description |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | ARLAS_CORS_ENABLED | arlas_cors.enabled | false | Whether to configure cors or not |
 | ARLAS_CORS_ALLOWED_ORIGINS | arlas_cors.allowed_origins | "*" | Comma-separated list of allowed origins |
 | ARLAS_CORS_ALLOWED_HEADERS | arlas_cors.allowed_headers | "arlas-user,arlas-groups,arlas-organization,X-Requested-With,Content-Type,Accept,Origin,Authorization,X-Forwarded-User" | Comma-separated list of allowed headers |

--- a/pom.xml
+++ b/pom.xml
@@ -241,14 +241,6 @@
       </releases>
     </repository>
     <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>boundless</id>
-      <name>Boundless Maven Repository</name>
-      <url>http://repo.boundlessgeo.com/main</url>
-    </repository>
-    <repository>
       <id>jcenter</id>
       <url>https://jcenter.bintray.com</url>
     </repository>


### PR DESCRIPTION
http://repo.boundlessgeo.com/main does not exists anymore.

ES needs to run in single instance mode in dev mode unless we can tune the system settings (which is not the case in Google Cloud Build).
