### PR TITLE
Fix sort on geo-fields in 'fetch_hits' parameter

### DIFF
--- a/arlas-core/src/main/java/io/arlas/server/app/Documentation.java
+++ b/arlas-core/src/main/java/io/arlas/server/app/Documentation.java
@@ -102,7 +102,7 @@ public class Documentation {
     public static final String AGGREGATION_OPERATION = "Aggregate the elements in the collection(s), given the filters and the aggregation parameters";
     public static final String AGGREGATION_PARAM_AGG = "- The agg parameter should be given in the following formats:  " +
             "\n \n" +
-            "       {type}:{field}:interval-{interval}:format-{format}:collect_field-{collect_field}:collect_fct-{function}:order-{order}:on-{on}:size-{size} " +
+            "       {type}:{field}:interval-{interval}:format-{format}:collect_field-{collect_field}:collect_fct-{function}:order-{order}:on-{on}:size-{size}:fetch_hits-{fetch_hits values} " +
             "\n \n" +
             "Where :" +
             "\n \n" +
@@ -213,7 +213,7 @@ public class Documentation {
     public static final String GEOHASH_GEOAGGREGATION_OPERATION = "Aggregate the elements in the collection(s) and localized in the given geohash as features, given the filters and the aggregation parameters.";
     public static final String GEOAGGREGATION_PARAM_AGG = "- The agg parameter should be given in the following formats:  " +
             "\n \n" +
-            "       {type}:{field}:interval-{interval}:format-{format}:collect_field-{collect_field}:collect_fct-{function}:order-{order}:on-{on}:size-{size}:fetcbGeometry-{fetch_geometry values}" +
+            "       {type}:{field}:interval-{interval}:format-{format}:collect_field-{collect_field}:collect_fct-{function}:order-{order}:on-{on}:size-{size}:raw_geometries-{raw_geometries values}:aggregated_geometries-{aggregated_geometries values}:fetch_hits-{fetch_hits values}" +
             "\n \n" +
             "Where :" +
             "\n \n" +

--- a/arlas-core/src/main/java/io/arlas/server/impl/elastic/core/FluidSearch.java
+++ b/arlas-core/src/main/java/io/arlas/server/impl/elastic/core/FluidSearch.java
@@ -833,11 +833,18 @@ public class FluidSearch {
                     String unsignedField = (field.startsWith("+") || field.startsWith("-")) ? field.substring(1) : field;
                     ElasticTool.checkAliasMappingFields(client, collectionReference.params.indexName, unsignedField);
                     includes.add(unsignedField);
-                    if (field.startsWith("+") || !field.startsWith("-")) {
-                        topHitsAggregationBuilder.sort(unsignedField, SortOrder.ASC);
-                    } else {
-                        topHitsAggregationBuilder.sort(unsignedField, SortOrder.DESC);
+                    /** For geo-fields, we don't sort them. Sorting geo-fields need to be according a given point to calculate a geo-distance
+                     * which is not supported in the syntax of fetch_hits*/
+                    if (CollectionReferenceManager.getInstance().getType(collectionReference, unsignedField, false) != ElasticType.GEO_POINT && CollectionReferenceManager.getInstance().getType(collectionReference, unsignedField, false) != ElasticType.GEO_SHAPE) {
+                        if (field.startsWith("+") || !field.startsWith("-")) {
+                            topHitsAggregationBuilder.sort(unsignedField, SortOrder.ASC);
+                        } else {
+                            topHitsAggregationBuilder.sort(unsignedField, SortOrder.DESC);
+                        }
                     }
+
+
+
                 }
                 String[] hitsToInclude = includes.toArray(new String[includes.size()]);
                 topHitsAggregationBuilder.fetchSource(hitsToInclude, null);

--- a/arlas-tests/src/test/java/io/arlas/server/rest/explore/AbstractAggregatedTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/rest/explore/AbstractAggregatedTest.java
@@ -390,6 +390,12 @@ public abstract class AbstractAggregatedTest extends AbstractFormattedTest {
         handleMatchingHistogramAggregateWithFetchedHits(post(aggregationRequest), 10, 3, "params.country", "params.startdate");
         handleMatchingHistogramAggregateWithFetchedHits(get("histogram:params.startdate:interval-60000:fetch_hits-3(params.country,params.startdate)"), 10, 3, "params.country", "params.startdate");
 
+
+        aggregationRequest.aggregations.get(0).interval = new Interval(60000, null); //"1minute";
+        aggregationRequest.aggregations.get(0).fetchHits = new HitsFetcher(3, Arrays.asList("geo_params.geometry"));
+        handleMatchingHistogramAggregateWithFetchedHits(post(aggregationRequest), 10, 3, "geo_params.geometry");
+        handleMatchingHistogramAggregateWithFetchedHits(get("histogram:params.startdate:interval-60000:fetch_hits-3(geo_params.geometry)"), 10, 3, "geo_params.geometry");
+
         aggregationRequest.aggregations.get(0).fetchHits = new HitsFetcher(3, Arrays.asList("-params.startdate"));
         handleMatchingHistogramAggregateWithSortedFetchedDates(post(aggregationRequest), 10, 3, 763600, 1263600, "params.startdate");
         handleMatchingHistogramAggregateWithSortedFetchedDates(get("histogram:params.startdate:interval-60000:fetch_hits-3(-params.startdate)"), 10, 3, 763600, 1263600, "params.startdate");


### PR DESCRIPTION
- sorting on geometries need to be a geo-distance which is not supported by our api