### PR TITLE
Fix pagination for _geosearch endpoint

### DIFF
--- a/arlas-core/src/main/java/io/arlas/server/core/impl/elastic/services/ElasticExploreService.java
+++ b/arlas-core/src/main/java/io/arlas/server/core/impl/elastic/services/ElasticExploreService.java
@@ -256,7 +256,7 @@ public class ElasticExploreService extends ExploreService {
 
     @Override
     public FeatureCollection getFeatures(MixedRequest request, CollectionReference collectionReference,
-                                         FluidSearchService fluidSearch, boolean flat, UriInfo uriInfo, String method,
+                                         boolean flat, UriInfo uriInfo, String method,
                                          HashMap<String, Object> context) throws ArlasException {
         SearchHits searchHits = getSearchHits(request, collectionReference);
         long totalnb = searchHits.getTotalHits().value;

--- a/arlas-core/src/main/java/io/arlas/server/core/impl/jdbi/service/JdbiExploreService.java
+++ b/arlas-core/src/main/java/io/arlas/server/core/impl/jdbi/service/JdbiExploreService.java
@@ -154,8 +154,9 @@ public class JdbiExploreService extends ExploreService {
 
     @Override
     public FeatureCollection getFeatures(MixedRequest request, CollectionReference collectionReference,
-                                         FluidSearchService fluidSearch, boolean flat, UriInfo uriInfo,
+                                         boolean flat, UriInfo uriInfo,
                                          String method, HashMap<String, Object> context) throws ArlasException {
+        FluidSearchService fluidSearch = getSearchRequest(request, collectionReference);
         SelectRequest req = ((JdbiFluidSearch) fluidSearch).getRequest(true);
         Search searchRequest = (Search) request.basicRequest;
         FeatureCollection fc = new FeatureCollection();

--- a/arlas-core/src/main/java/io/arlas/server/core/services/ExploreService.java
+++ b/arlas-core/src/main/java/io/arlas/server/core/services/ExploreService.java
@@ -366,16 +366,6 @@ public abstract class ExploreService {
         return getFeatures(request, collectionReference, flat, null, null, null);
     }
 
-    public FeatureCollection getFeatures(MixedRequest request,
-                                         CollectionReference collectionReference,
-                                         boolean flat,
-                                         UriInfo uriInfo,
-                                         String method,
-                                         HashMap<String, Object> context) throws ArlasException {
-        FluidSearchService fluidSearch = getSearchRequest(request, collectionReference);
-        return getFeatures(request, collectionReference, fluidSearch, flat, uriInfo, method, context);
-    }
-
     protected FluidSearchService getSearchRequest(MixedRequest request, CollectionReference collectionReference) throws ArlasException {
         FluidSearchService fluidSearch = getFluidSearch(collectionReference);
         applyFilter(collectionReference.params.filter, fluidSearch);
@@ -405,7 +395,6 @@ public abstract class ExploreService {
 
     public abstract FeatureCollection getFeatures(MixedRequest request,
                                                   CollectionReference collectionReference,
-                                                  FluidSearchService fluidSearch,
                                                   boolean flat,
                                                   UriInfo uriInfo,
                                                   String method,

--- a/arlas-rest/src/main/java/io/arlas/server/rest/explore/search/SearchRESTService.java
+++ b/arlas-rest/src/main/java/io/arlas/server/rest/explore/search/SearchRESTService.java
@@ -175,7 +175,7 @@ public class SearchRESTService extends ExploreRESTServices {
 
         Search search = new Search();
         search.filter = ParamsParser.getFilter(collectionReference, f, q, dateformat);
-        search.page = ParamsParser.getPage(size, from, sort,after,before);
+        search.page = ParamsParser.getPage(size, from, sort, after, before);
         search.projection = ParamsParser.getProjection(include, exclude);
         search.returned_geometries = returned_geometries;
         exploreService.setValidGeoFilters(collectionReference, search);


### PR DESCRIPTION
`_geosearch` was calling `getSearchRequest` twice, which means calling `Paginate` twice

`Paginate` inverses the `sort`parameter direction if `before` parameter is set. Calling `Paginate` twice cancels the desired effect

- Fix #755 