### PR TITLE
Fix: rollback email header

### DIFF
--- a/arlas-commons/src/main/java/io/arlas/commons/config/ArlasAuthConfiguration.java
+++ b/arlas-commons/src/main/java/io/arlas/commons/config/ArlasAuthConfiguration.java
@@ -39,9 +39,6 @@ public class ArlasAuthConfiguration {
     @JsonProperty("header_user")
     public String headerUser;
 
-    @JsonProperty("header_email")
-    public String headerEmail = "arlas-user-email";
-
     @JsonProperty("header_group")
     public String headerGroup;
 

--- a/arlas-commons/src/main/java/io/arlas/filter/core/IdentityParam.java
+++ b/arlas-commons/src/main/java/io/arlas/filter/core/IdentityParam.java
@@ -33,7 +33,6 @@ import static io.arlas.commons.rest.utils.ServerConstants.*;
 public class IdentityParam {
 
     public final String userId;
-    public final Optional<String> email;
     public final List<String> organisation;
     public final List<String> groups;
     public final boolean isAnonymous;
@@ -42,7 +41,6 @@ public class IdentityParam {
     public IdentityParam(ArlasAuthConfiguration configuration, HttpHeaders headers) {
         this.userId = Optional.ofNullable(headers.getHeaderString(configuration.headerUser))
                 .orElse(configuration.anonymousValue);
-        this.email = Optional.ofNullable(headers.getHeaderString(configuration.headerEmail));
         this.isAnonymous = this.userId.equals(configuration.anonymousValue);
 
         // in a context where resources are publicly available, no organisation is defined

--- a/arlas-commons/src/main/java/io/arlas/filter/impl/AbstractPolicyEnforcer.java
+++ b/arlas-commons/src/main/java/io/arlas/filter/impl/AbstractPolicyEnforcer.java
@@ -103,11 +103,6 @@ public abstract class AbstractPolicyEnforcer implements PolicyEnforcer {
         return ((DecodedJWT) token).getSubject();
     }
 
-    protected Optional<String> getSubjectEmail(Object token) {
-        Claim emailClaim = ((DecodedJWT) token).getClaim("email");
-        return emailClaim.isNull() ? Optional.empty() : Optional.of(emailClaim.asString());
-    }
-
     protected Map<String, Object> getRolesClaim(Object token, Optional<String> org) {
         Claim jwtClaimRoles = ((DecodedJWT) token).getClaim(authConf.claimRoles);
         if (!jwtClaimRoles.isNull()) {
@@ -233,12 +228,6 @@ public abstract class AbstractPolicyEnforcer implements PolicyEnforcer {
                     if (orgFilter != null) {
                         MDC.put(ORGANIZATION_NAME, orgFilter);
                     }
-                }
-                ctx.getHeaders().remove(authConf.headerEmail); // remove it in case it's been set manually
-                Optional<String> email = getSubjectEmail(token);
-                if (email.isPresent()) {
-                    ctx.getHeaders().putSingle(authConf.headerEmail, email.get());
-                    LOGGER.debug("Add Header [" + authConf.headerEmail + "]");
                 }
 
                 ctx.getHeaders().remove(authConf.headerGroup); // remove it in case it's been set manually

--- a/conf/configuration.yaml
+++ b/conf/configuration.yaml
@@ -184,7 +184,6 @@ arlas_auth:
   certificate_file: ${ARLAS_AUTH_CERT_FILE:-/opt/app/arlas.pem}
   certificate_url: ${ARLAS_AUTH_CERT_URL:-}
   header_user: ${ARLAS_HEADER_USER:-arlas-user}
-  header_email: ${ARLAS_HEADER_EMAIL:-arlas-user-email}
   header_group: ${ARLAS_HEADER_GROUP:-arlas-groups}
   anonymous_value: ${ARLAS_ANONYMOUS_VALUE:-anonymous}
   claim_roles: ${ARLAS_CLAIM_ROLES:-http://arlas.io/roles}

--- a/docs/arlas-iam.md
+++ b/docs/arlas-iam.md
@@ -42,7 +42,6 @@ Further configuration may be required depending on the chosen implementation:
 |------------------------------|----------------------------------------|-----------------------------------------------------------|-----------------|
 | ARLAS_AUTH_PUBLIC_URIS       | arlas_auth.public_uris                 | swagger.\*:\*                                             | All             |
 | ARLAS_HEADER_USER            | arlas_auth.header_user                 | arlas-user                                                | All             |
-| ARLAS_HEADER_EMAIL           | arlas_auth.header_email                | arlas-user-email                                          | All             |
 | ARLAS_HEADER_GROUP           | arlas_auth.header_group                | arlas-groups                                              | All             |
 | ARLAS_ANONYMOUS_VALUE        | arlas_auth.anonymous_value             | anonymous                                                 | All             |
 | ARLAS_CLAIM_ROLES            | arlas_auth.claim_roles                 | http://arlas.io/roles                                     | Auth0,HTTP      |


### PR DESCRIPTION
Rollback because not needed after all: the email being in the JWT, it is enough for external services.