### PR TITLE
Feat:externalize partition filter in ES query

### DIFF
--- a/arlas-commons/src/main/java/io/arlas/filter/impl/AbstractPolicyEnforcer.java
+++ b/arlas-commons/src/main/java/io/arlas/filter/impl/AbstractPolicyEnforcer.java
@@ -235,7 +235,9 @@ public abstract class AbstractPolicyEnforcer implements PolicyEnforcer {
                 Object token = getObjectToken(accessToken, orgFilter);
                 Set<String> permissions = getPermissionsClaim(token);
                 Optional<String> org = Optional.ofNullable(new ArlasClaims(permissions.stream().toList()).getVariables().get(VAR_ORG));
-
+                if(ctx.getHeaders().get(PARTITION_FILTER) != null){
+                    ctx.getHeaders().remove(PARTITION_FILTER); // remove it in case it's been set manually
+                }
                 ctx.getHeaders().remove(authConf.headerUser); // remove it in case it's been set manually
                 String userId = getSubject(token);
                 if (!StringUtil.isNullOrEmpty(userId)) {

--- a/arlas-core/src/main/java/io/arlas/server/core/model/request/Request.java
+++ b/arlas-core/src/main/java/io/arlas/server/core/model/request/Request.java
@@ -20,7 +20,10 @@
 package io.arlas.server.core.model.request;
 
 
+import java.util.List;
+
 public class Request {
+    public List<Filter> partitionFilter;
     public Filter filter;
     public Form form;
 }

--- a/arlas-core/src/main/java/io/arlas/server/core/services/FluidSearchService.java
+++ b/arlas-core/src/main/java/io/arlas/server/core/services/FluidSearchService.java
@@ -25,10 +25,7 @@ import io.arlas.server.core.managers.CollectionReferenceManager;
 import io.arlas.server.core.model.CollectionReference;
 import io.arlas.server.core.model.enumerations.AggregationTypeEnum;
 import io.arlas.server.core.model.enumerations.ComputationEnum;
-import io.arlas.server.core.model.request.Aggregation;
-import io.arlas.server.core.model.request.Expression;
-import io.arlas.server.core.model.request.MultiValueFilter;
-import io.arlas.server.core.model.request.Page;
+import io.arlas.server.core.model.request.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -192,6 +189,8 @@ public abstract class FluidSearchService {
     public abstract FluidSearchService compute(String field, ComputationEnum metric, int precisionThresold) throws ArlasException;
 
     abstract public FluidSearchService filter(MultiValueFilter<Expression> f, String dateFormat, Boolean rightHand) throws ArlasException;
+
+    public abstract FluidSearchService partitionFilter(List<Filter> filters)throws ArlasException;
 
     abstract public FluidSearchService filterQ(MultiValueFilter<String> q) throws ArlasException;
 

--- a/arlas-core/src/main/java/io/arlas/server/core/utils/ParamsParser.java
+++ b/arlas-core/src/main/java/io/arlas/server/core/utils/ParamsParser.java
@@ -260,7 +260,7 @@ public class ParamsParser {
         return Objects.requireNonNullElse(aggFormat, "yyyy-MM-dd-HH:mm:ss");
     }
 
-    public static Filter getFilter(CollectionReference collectionReference, String serializedFilter) throws InvalidParameterException {
+    public static List<Filter> getPartitionFilter(CollectionReference collectionReference, String serializedFilter) throws InvalidParameterException {
         if (serializedFilter != null) {
             List<Filter> fList;
             String sf = "[" + serializedFilter + "]";
@@ -278,19 +278,7 @@ public class ParamsParser {
                     throw new InvalidParameterException(INVALID_FILTER + ": '" + sf + "'", ex);
                 }
             }
-            // if not null and parsing ok then we have at least one filter
-            if (fList != null && fList.size() > 0) {
-                Filter retFilter = fList.get(0);
-                if (retFilter.righthand == null) {
-                    retFilter.righthand = Boolean.TRUE;
-                }
-
-                for (int i = 1; i < fList.size(); i++) {
-                    // for now, a list of partition filters is combined with OR. TODO: support more complex combination
-                    retFilter.f.get(0).addAll(fList.get(i).f.get(0));
-                }
-                return retFilter;
-            }
+            return fList;
         }
         return null;
     }

--- a/arlas-rest/src/main/java/io/arlas/server/rest/explore/aggregate/AggregateRESTService.java
+++ b/arlas-rest/src/main/java/io/arlas/server/rest/explore/aggregate/AggregateRESTService.java
@@ -156,7 +156,7 @@ public class AggregateRESTService extends ExploreRESTServices {
         ColumnFilterUtil.assertRequestAllowed(Optional.ofNullable(columnFilter), collectionReference, aggregationsRequest);
 
         AggregationsRequest aggregationsRequestHeader = new AggregationsRequest();
-        aggregationsRequestHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        aggregationsRequestHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         MixedRequest request = new MixedRequest();
         request.basicRequest = aggregationsRequest;
         exploreService.setValidGeoFilters(collectionReference, aggregationsRequestHeader);
@@ -235,7 +235,7 @@ public class AggregateRESTService extends ExploreRESTServices {
         }
 
         AggregationsRequest aggregationsRequestHeader = new AggregationsRequest();
-        aggregationsRequestHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        aggregationsRequestHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         MixedRequest request = new MixedRequest();
         exploreService.setValidGeoFilters(collectionReference, aggregationsRequest);
         exploreService.setValidGeoFilters(collectionReference, aggregationsRequestHeader);

--- a/arlas-rest/src/main/java/io/arlas/server/rest/explore/aggregate/GeoAggregateRESTService.java
+++ b/arlas-rest/src/main/java/io/arlas/server/rest/explore/aggregate/GeoAggregateRESTService.java
@@ -683,7 +683,7 @@ public class GeoAggregateRESTService extends ExploreRESTServices {
         }
 
         AggregationsRequest aggregationsRequestHeader = new AggregationsRequest();
-        aggregationsRequestHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        aggregationsRequestHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         MixedRequest request = new MixedRequest();
         exploreService.setValidGeoFilters(collectionReference, aggregationRequest);
         exploreService.setValidGeoFilters(collectionReference, aggregationsRequestHeader);
@@ -765,7 +765,7 @@ public class GeoAggregateRESTService extends ExploreRESTServices {
         }
 
         AggregationsRequest aggregationsRequestHeader = new AggregationsRequest();
-        aggregationsRequestHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        aggregationsRequestHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         MixedRequest request = new MixedRequest();
         exploreService.setValidGeoFilters(collectionReference, aggregationRequest);
         exploreService.setValidGeoFilters(collectionReference, aggregationsRequestHeader);
@@ -799,7 +799,7 @@ public class GeoAggregateRESTService extends ExploreRESTServices {
         ColumnFilterUtil.assertRequestAllowed(columnFilter, collectionReference, aggregationsRequest);
 
         AggregationsRequest aggregationsRequestHeader = new AggregationsRequest();
-        aggregationsRequestHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        aggregationsRequestHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         MixedRequest request = new MixedRequest();
         request.basicRequest = aggregationsRequest;
         exploreService.setValidGeoFilters(collectionReference, aggregationsRequestHeader);

--- a/arlas-rest/src/main/java/io/arlas/server/rest/explore/compute/ComputeRESTService.java
+++ b/arlas-rest/src/main/java/io/arlas/server/rest/explore/compute/ComputeRESTService.java
@@ -159,7 +159,7 @@ public class ComputeRESTService extends ExploreRESTServices {
         ColumnFilterUtil.assertRequestAllowed(Optional.ofNullable(columnFilter), collectionReference, computationRequest);
 
         ComputationRequest computationRequestHeader = new ComputationRequest();
-        computationRequestHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        computationRequestHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         exploreService.setValidGeoFilters(collectionReference, computationRequestHeader);
         MixedRequest request = new MixedRequest();
         request.basicRequest = computationRequest;
@@ -233,7 +233,7 @@ public class ComputeRESTService extends ExploreRESTServices {
             throw new NotFoundException(collection);
         }
         ComputationRequest computationRequestHeader = new ComputationRequest();
-        computationRequestHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        computationRequestHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         MixedRequest request = new MixedRequest();
         exploreService.setValidGeoFilters(collectionReference, computationRequest);
         exploreService.setValidGeoFilters(collectionReference, computationRequestHeader);

--- a/arlas-rest/src/main/java/io/arlas/server/rest/explore/count/CountRESTService.java
+++ b/arlas-rest/src/main/java/io/arlas/server/rest/explore/count/CountRESTService.java
@@ -139,7 +139,7 @@ public class CountRESTService extends ExploreRESTServices {
         MixedRequest request = new MixedRequest();
         request.basicRequest = count;
         Count countHeader = new Count();
-        countHeader.filter = ParamsParser.getFilter(collectionReference, partitionfilter);
+        countHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionfilter);
         exploreService.setValidGeoFilters(collectionReference, countHeader);
         request.headerRequest = countHeader;
         request.columnFilter = ColumnFilterUtil.getCollectionRelatedColumnFilter(Optional.ofNullable(columnFilter), collectionReference);
@@ -213,7 +213,7 @@ public class CountRESTService extends ExploreRESTServices {
 
         request.basicRequest = count;
         Count countHeader = new Count();
-        countHeader.filter = ParamsParser.getFilter(collectionReference, partitionfilter);
+        countHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionfilter);
         exploreService.setValidGeoFilters(collectionReference, countHeader);
         request.headerRequest = countHeader;
         request.columnFilter = ColumnFilterUtil.getCollectionRelatedColumnFilter(Optional.ofNullable(columnFilter), collectionReference);

--- a/arlas-rest/src/main/java/io/arlas/server/rest/explore/search/GeoSearchRESTService.java
+++ b/arlas-rest/src/main/java/io/arlas/server/rest/explore/search/GeoSearchRESTService.java
@@ -560,7 +560,7 @@ public class GeoSearchRESTService extends ExploreRESTServices {
         CheckParams.checkReturnedGeometries(collectionReference, includes, excludes, search.returned_geometries);
 
         Search searchHeader = new Search();
-        searchHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        searchHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         exploreService.setValidGeoFilters(collectionReference, search);
         exploreService.setValidGeoFilters(collectionReference, searchHeader);
 
@@ -644,7 +644,7 @@ public class GeoSearchRESTService extends ExploreRESTServices {
         CheckParams.checkReturnedGeometries(collectionReference, includes, excludes, search.returned_geometries);
 
         Search searchHeader = new Search();
-        searchHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        searchHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
 
         exploreService.setValidGeoFilters(collectionReference, search);
         exploreService.setValidGeoFilters(collectionReference, searchHeader);
@@ -689,7 +689,7 @@ public class GeoSearchRESTService extends ExploreRESTServices {
         search.projection = ParamsParser.enrichIncludes(search.projection, returned_geometries);
 
         Search searchHeader = new Search();
-        searchHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        searchHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         MixedRequest request = new MixedRequest();
         request.basicRequest = search;
         exploreService.setValidGeoFilters(collectionReference, searchHeader);

--- a/arlas-rest/src/main/java/io/arlas/server/rest/explore/search/SearchRESTService.java
+++ b/arlas-rest/src/main/java/io/arlas/server/rest/explore/search/SearchRESTService.java
@@ -203,7 +203,7 @@ public class SearchRESTService extends ExploreRESTServices {
         search.projection = ParamsParser.enrichIncludes(search.projection, returned_geometries);
 
         Search searchHeader = new Search();
-        searchHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        searchHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         MixedRequest request = new MixedRequest();
         request.basicRequest = search;
         exploreService.setValidGeoFilters(collectionReference, searchHeader);
@@ -282,7 +282,7 @@ public class SearchRESTService extends ExploreRESTServices {
         String excludes = search.projection != null ? search.projection.excludes : null;
 
         Search searchHeader = new Search();
-        searchHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        searchHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
 
         exploreService.setValidGeoFilters(collectionReference, search);
         exploreService.setValidGeoFilters(collectionReference, searchHeader);

--- a/arlas-rest/src/main/java/io/arlas/server/rest/plugins/eo/TileRESTService.java
+++ b/arlas-rest/src/main/java/io/arlas/server/rest/plugins/eo/TileRESTService.java
@@ -207,7 +207,7 @@ public class TileRESTService extends ExploreRESTServices {
         ColumnFilterUtil.assertRequestAllowed(Optional.ofNullable(columnFilter), collectionReference, search);
 
         Search searchHeader = new Search();
-        searchHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        searchHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         MixedRequest request = new MixedRequest();
         request.basicRequest = search;
         request.headerRequest = searchHeader;

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/ATOMSearchServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/ATOMSearchServiceIT.java
@@ -100,6 +100,17 @@ public class ATOMSearchServiceIT extends AbstractProjectedTest {
     }
 
     @Override
+    public void handleMultiPartitionFilter(ValidatableResponse then) throws Exception {
+        if (then.extract().contentType().equals(ATOM.APPLICATION_ATOM_XML)) {
+            then.statusCode(200)
+                    .body(ATOM.XML_PREFIX + ":feed.totalResults", equalTo("33"));
+        } else {
+            then.statusCode(200)
+                    .body("totalnb", equalTo(33));
+        }
+    }
+
+    @Override
     protected void handleFieldFilter(ValidatableResponse then, int nbResults, String... values) throws Exception {
         if (then.extract().contentType().equals(ATOM.APPLICATION_ATOM_XML)) {
             then.statusCode(200)

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AggregateServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AggregateServiceIT.java
@@ -347,6 +347,12 @@ public class AggregateServiceIT extends AbstractAggregatedTest {
     }
 
     @Override
+    protected void handleMultiPartitionFilter(ValidatableResponse then) throws Exception {
+        then.statusCode(200)
+                .body("elements.size()", equalTo(33));
+    }
+
+    @Override
     protected void handleFieldFilter(ValidatableResponse then, int nbResults, String... values) throws Exception {
         handleFieldFilter(then, nbResults);
     }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/ComputeServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/ComputeServiceIT.java
@@ -98,6 +98,11 @@ public class ComputeServiceIT extends AbstractComputationTest {
     }
 
     @Override
+    protected void handleMultiPartitionFilter(ValidatableResponse then) throws Exception {
+        handleMatchingFilter(then, 33);
+    }
+
+    @Override
     protected void handleFieldFilter(ValidatableResponse then, int nbResults, String... values) throws Exception {
         handleFieldFilter(then, nbResults);
     }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/CountServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/CountServiceIT.java
@@ -62,6 +62,11 @@ public class CountServiceIT extends AbstractFilteredTest {
     }
 
     @Override
+    public void handleMultiPartitionFilter(ValidatableResponse then) throws Exception {
+        handleMatchingFilter(then, 33);
+    }
+
+    @Override
     protected void handleFieldFilter(ValidatableResponse then, int nbResults, String... values) throws Exception {
         handleFieldFilter(then, nbResults);
     }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/GeoAggregateServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/GeoAggregateServiceIT.java
@@ -340,6 +340,11 @@ public class    GeoAggregateServiceIT extends AbstractGeohashTiledTest {
     }
 
     @Override
+    protected void handleMultiPartitionFilter(ValidatableResponse then) throws Exception {
+        then.statusCode(200).body("features.size()", equalTo(33));;
+    }
+
+    @Override
     protected void handleFieldFilter(ValidatableResponse then, int nbResults, String... values) throws Exception {
         handleFieldFilter(then, nbResults);
     }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/GeoSearchServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/GeoSearchServiceIT.java
@@ -60,7 +60,7 @@ public class GeoSearchServiceIT extends AbstractXYZTiledTest {
     //----------------------------------------------------------------
     @Override
     protected RequestSpecification givenFilterableRequestParams() {
-        return given();
+        return  given();
     }
 
     @Override
@@ -79,6 +79,11 @@ public class GeoSearchServiceIT extends AbstractXYZTiledTest {
                 .body("features[0].properties.md.centroid.type", equalTo("Point"))
                 .body("features[0].properties.md.centroid", hasKey("coordinates"))
                 .body("features[0].properties.md.geometry", isEmptyOrNullString());
+    }
+
+    @Override
+    protected void handleMultiPartitionFilter(ValidatableResponse then) throws Exception {
+        then.statusCode(200).body("features[0].properties.params.job", equalTo("Architect"));
     }
 
     @Override

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/SearchServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/SearchServiceIT.java
@@ -79,6 +79,13 @@ public class SearchServiceIT extends AbstractProjectedTest {
     }
 
     @Override
+    public void handleMultiPartitionFilter(ValidatableResponse then) throws Exception {
+        then.statusCode(200)
+                .body("totalnb", equalTo(33));
+
+    }
+
+    @Override
     protected void handleFieldFilter(ValidatableResponse then, int nbResults, String... values) throws Exception {
         then.statusCode(200)
                 .body("totalnb", equalTo(nbResults))

--- a/docs/arlas-api-exploration.md
+++ b/docs/arlas-api-exploration.md
@@ -283,6 +283,12 @@ In the case of `lt`, `gt`, `lte`, `gte`, `range` operations that are applied on 
 When dealing with multi collections, filter can also be specified in a JSON map <collection name, filter>, e.g.:
 > Example: `curl --header "partition-filter: {"mycollection1": {"f":[[{"field":"city","op":"eq","value":"Bordeaux"}]]}}" https://api.gisaia.com/demo/arlas/explore/cities/_count`
 
+You can pass several filter in `partition-filter`, separated by comma :
+
+> Example: `curl --header "partition-filter: {"f":[[{"field":"city","op":"eq","value":"Bordeaux"}]]},{"f":[[{"field":"city","op":"eq","value":"Paris"}]]}" https://api.gisaia.com/demo/arlas/explore/cities/_count`
+
+In this case a OR combination is done.
+
 #### Column filtering
 
 A comma-separated list of columns can be passed in request header `column-filter`. Wildcards are supported.

--- a/ogc-wfs/src/main/java/io/arlas/server/ogc/wfs/services/ElasticWFSToolService.java
+++ b/ogc-wfs/src/main/java/io/arlas/server/ogc/wfs/services/ElasticWFSToolService.java
@@ -22,7 +22,6 @@ import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.GeoBounds;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.GeoBoundingBoxQuery;
-import co.elastic.clients.elasticsearch._types.query_dsl.GeoShapeQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
@@ -218,19 +217,24 @@ public class ElasticWFSToolService implements WFSToolService {
     }
 
     private void addPartitionFilter(CollectionReference collectionReference, ElasticFluidSearch fluidSearch, String partitionFilter) throws ArlasException {
-        Filter headerFilter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        List<Filter> headerFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         Filter collectionFilter = collectionReference.params.filter;
-        Boolean applyFilter = false;
+        Boolean applyCollectionFilter = false;
+        Boolean applyPartitionFilter = false;
+
         if(collectionFilter != null){
             exploreServices.applyFilter(collectionFilter, fluidSearch);
-            applyFilter = true;
+            applyCollectionFilter = true;
         }
-        if(headerFilter.f != null || headerFilter.q != null){
-            exploreServices.applyFilter(headerFilter, fluidSearch);
-            applyFilter = true;
+        if(headerFilter != null){
+            exploreServices.applyPartitionFilter(headerFilter, fluidSearch);
+            applyPartitionFilter = true;
         }
-        if(applyFilter){
+        if(applyCollectionFilter){
             wfsQuery.filter(fluidSearch.getBoolQueryBuilder().build()._toQuery());
+        }
+        if(applyPartitionFilter){
+            wfsQuery.filter(fluidSearch.getBoolPartitionQueryBuilder().build()._toQuery());
         }
     }
 

--- a/stac-api/src/main/java/io/arlas/server/stac/api/StacRESTService.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/StacRESTService.java
@@ -245,7 +245,7 @@ public abstract class StacRESTService {
         ColumnFilterUtil.assertRequestAllowed(columnFilter, collectionReference, search);
 
         Search searchHeader = new Search();
-        searchHeader.filter = ParamsParser.getFilter(collectionReference, partitionFilter);
+        searchHeader.partitionFilter = ParamsParser.getPartitionFilter(collectionReference, partitionFilter);
         MixedRequest request = new MixedRequest();
         request.basicRequest = search;
         request.headerRequest = searchHeader;


### PR DESCRIPTION
- Fix #964 
 We remove the partition-filter header in case it's been set manually 
- Fix #966 