### PR TITLE
Feat: implement stac filter extension

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -121,6 +121,19 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
         run: scripts/ci/tests-integration-stage.sh --stage=STAC
 
+  run-test-stac-filter:
+    runs-on: ubuntu-latest
+    name: Run tests [STAC-FILTER]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/workflows/prepare
+      - name: Run tests [STAC-FILTER]
+        env:
+          # secrets are defined here : https://github.com/organizations/gisaia/settings/secrets/actions
+          DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        run: scripts/ci/tests-integration-stage.sh --stage=STAC_FILTER
+
   run-test-stac-eo:
     runs-on: ubuntu-latest
     name: Run tests [STAC ARLAS EO]

--- a/arlas-core/pom.xml
+++ b/arlas-core/pom.xml
@@ -34,8 +34,8 @@
         <!-- Tests -->
         <!-- ____________________________________________________ -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>

--- a/arlas-tests/pom.xml
+++ b/arlas-tests/pom.xml
@@ -19,14 +19,33 @@
             <artifactId>arlas-server</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- ____________________________________________________ -->
-        <!-- Tests -->
-        <!-- ____________________________________________________ -->
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${io.rest-assured.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <version>${jts.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-geojson</artifactId>
+            <version>${geotools.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/arlas-tests/src/test/java/io/arlas/server/tests/AbstractTestWithCollection.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/AbstractTestWithCollection.java
@@ -23,8 +23,8 @@ import io.arlas.server.core.app.ArlasServerConfiguration;
 import io.arlas.commons.exceptions.ArlasException;
 import io.arlas.server.core.model.request.Filter;
 import io.arlas.server.core.model.request.Request;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 
@@ -41,12 +41,12 @@ public abstract class AbstractTestWithCollection extends AbstractTestContext {
         request.filter.righthand = false;
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws ArlasException, IOException {
         new CollectionTool().load(10000);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() throws IOException, ArlasException {
         new CollectionTool().delete(true);
     }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/AbstractTestWithDataSet.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/AbstractTestWithDataSet.java
@@ -22,8 +22,8 @@ package io.arlas.server.tests;
 import io.arlas.commons.exceptions.ArlasException;
 import io.arlas.server.core.model.request.Filter;
 import io.arlas.server.core.model.request.Request;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -37,7 +37,7 @@ public abstract class AbstractTestWithDataSet extends AbstractTestContext {
         request.filter.righthand = false;
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         try {
             DataSetTool.loadDataSet(false);
@@ -56,7 +56,7 @@ public abstract class AbstractTestWithDataSet extends AbstractTestContext {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() throws IOException, ArlasException {
         DataSetTool.clearDataSet();
     }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/CollectionTool.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/CollectionTool.java
@@ -29,7 +29,7 @@ import io.arlas.server.core.model.enumerations.OperatorEnum;
 import io.arlas.server.core.model.request.Expression;
 import io.arlas.server.core.model.request.Filter;
 import io.arlas.server.core.model.request.MultiValueFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -195,6 +195,10 @@ public class CollectionTool extends AbstractTestContext {
             when().delete(arlasPath + "collections/" + COLLECTION_NAME_ACTOR).then().statusCode(200);
         }
         DataSetTool.clearDataSet();
+    }
+    @Test
+    public  void delete() throws IOException, ArlasException {
+        this.delete(true);
     }
 
     public  void deleteCsw() throws IOException, ArlasException {

--- a/arlas-tests/src/test/java/io/arlas/server/tests/auth/AuthServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/auth/AuthServiceIT.java
@@ -21,7 +21,8 @@ package io.arlas.server.tests.auth;
 
 import io.arlas.server.tests.AbstractTestContext;
 import jakarta.ws.rs.core.HttpHeaders;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;

--- a/arlas-tests/src/test/java/io/arlas/server/tests/ogc/csw/CSWServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/ogc/csw/CSWServiceIT.java
@@ -29,9 +29,10 @@ import io.restassured.specification.RequestSpecification;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.Matchers;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -53,7 +54,7 @@ public class CSWServiceIT extends AbstractTestWithCollection {
         return arlasPath + "ogc/csw";
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws ArlasException, IOException {
         InputStreamReader dcelementForCollection = new InputStreamReader(CollectionTool.class.getClassLoader().getResourceAsStream("csw.collection.dcelements.json"));
         dcelements = new ObjectMapper().readValue(dcelementForCollection, DublinCoreElementName[].class);
@@ -61,7 +62,7 @@ public class CSWServiceIT extends AbstractTestWithCollection {
         new CollectionTool().loadCsw(10000l);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() throws IOException, ArlasException {
         new CollectionTool().deleteCsw();
     }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/ogc/csw/CSWServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/ogc/csw/CSWServiceIT.java
@@ -22,6 +22,7 @@ package io.arlas.server.tests.ogc.csw;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.arlas.commons.exceptions.ArlasException;
 import io.arlas.server.core.model.DublinCoreElementName;
+import io.arlas.server.tests.AbstractTestContext;
 import io.arlas.server.tests.AbstractTestWithCollection;
 import io.arlas.server.tests.CollectionTool;
 import io.restassured.response.ValidatableResponse;
@@ -45,7 +46,7 @@ import static io.arlas.commons.rest.utils.ServerConstants.COLUMN_FILTER;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 
-public class CSWServiceIT extends AbstractTestWithCollection {
+public class CSWServiceIT extends AbstractTestContext {
 
     static DublinCoreElementName[] dcelements;
 

--- a/arlas-tests/src/test/java/io/arlas/server/tests/ogc/wfs/WFSServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/ogc/wfs/WFSServiceIT.java
@@ -27,7 +27,8 @@ import io.arlas.server.core.model.enumerations.OperatorEnum;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.Optional;
 import static org.hamcrest.Matchers.*;

--- a/arlas-tests/src/test/java/io/arlas/server/tests/ogc/wfs/WFSServiceWithOgcFilterIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/ogc/wfs/WFSServiceWithOgcFilterIT.java
@@ -22,136 +22,140 @@ package io.arlas.server.tests.ogc.wfs;
 import io.arlas.server.core.model.request.Filter;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import java.util.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class WFSServiceWithOgcFilterIT extends AbstractWFSServiceTest {
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
-    private String testFilter;
+class WFSServiceWithOgcFilterIT extends AbstractWFSServiceTest {
 
-    public WFSServiceWithOgcFilterIT(String testName, String testFilter) {
-        this.testFilter = testFilter;
-    }
-
-    @Test
-    public void testGetFeatureFilter() throws Exception {
-        //TODO test the result, not only response code
+    @ParameterizedTest(name = "GetFeature filter [{index}] {0}")
+    @MethodSource("filters")
+    void testGetFeatureFilter(String testName, String testFilter) throws Exception {
         handleOK(
-                get(getFeatureParams(),
+                get(getFeatureParams(testFilter),
                         new Filter())
         );
     }
 
-    @Test
-    public void testGetFeatureFilterWithEmptyColumnFilter() throws Exception {
+    @ParameterizedTest(name = "GetFeature empty column filter [{index}] {0}")
+    @MethodSource("filters")
+    void testGetFeatureFilterWithEmptyColumnFilter(String testName, String testFilter) throws Exception {
         handleOK(
-                get(getFeatureParams(),
+                get(getFeatureParams(testFilter),
                         new Filter(),
                         Optional.empty())
         );
     }
 
-    @Test
-    public void testGetFeatureFilterWithAvailableColumns() throws Exception {
+    @ParameterizedTest(name = "GetFeature available columns [{index}] {0}")
+    @MethodSource("filters")
+    void testGetFeatureFilterWithAvailableColumns(String testName, String testFilter) throws Exception {
         handleOK(
-                get(getFeatureParams(),
+                get(getFeatureParams(testFilter),
                         new Filter(),
                         Optional.of("params"))
         );
     }
 
-    @Test
-    public void testGetFeatureFilterWithUnavailableColumns() throws Exception {
+    @ParameterizedTest(name = "GetFeature unavailable columns [{index}] {0}")
+    @MethodSource("filters")
+    void testGetFeatureFilterWithUnavailableColumns(String testName, String testFilter) throws Exception {
         handleUnavailableColumn(
-                get(getFeatureParams(),
+                get(getFeatureParams(testFilter),
                         new Filter(),
                         Optional.of("fullname"))
         );
     }
 
-    @Test
-    public void testGetFeatureFilterWithCollectionBasedColumnFiltering() throws Exception {
+    @ParameterizedTest(name = "GetFeature collection based column filtering [{index}] {0}")
+    @MethodSource("filters")
+    void testGetFeatureFilterWithCollectionBasedColumnFiltering(String testName, String testFilter) throws Exception {
         handleOK(
-                get(getFeatureParams(),
+                get(getFeatureParams(testFilter),
                         new Filter(),
                         Optional.of(COLLECTION_NAME + ":params"))
         );
 
         handleUnavailableColumn(
-                get(getFeatureParams(),
+                get(getFeatureParams(testFilter),
                         new Filter(),
                         Optional.of("notExisting:params,fullname"))
         );
 
         handleUnavailableCollection(
-                get(getFeatureParams(),
+                get(getFeatureParams(testFilter),
                         new Filter(),
                         Optional.of("notExisting:params"))
         );
     }
 
-    @Test
-    public void testGetPropertyValueFilter() throws Exception {
-        //TODO test the result, not only response code
+    @ParameterizedTest(name = "GetPropertyValue filter [{index}] {0}")
+    @MethodSource("filters")
+    void testGetPropertyValueFilter(String testName, String testFilter) throws Exception {
         handleOK(
-                get(getGetPropertyValueParams(),
+                get(getGetPropertyValueParams(testFilter),
                         new Filter())
         );
     }
 
-    @Test
-    public void testGetPropertyValueFilterWithEmptyColumnFilter() throws Exception {
+    @ParameterizedTest(name = "GetPropertyValue empty column filter [{index}] {0}")
+    @MethodSource("filters")
+    void testGetPropertyValueFilterWithEmptyColumnFilter(String testName, String testFilter) throws Exception {
         handleOK(
-                get(getGetPropertyValueParams(),
+                get(getGetPropertyValueParams(testFilter),
                         new Filter(),
                         Optional.empty())
         );
     }
 
-    @Test
-    public void testGetPropertyValueFilterWithAvailableColumns() throws Exception {
+    @ParameterizedTest(name = "GetPropertyValue available columns [{index}] {0}")
+    @MethodSource("filters")
+    void testGetPropertyValueFilterWithAvailableColumns(String testName, String testFilter) throws Exception {
         handleOK(
-                get(getGetPropertyValueParams(),
+                get(getGetPropertyValueParams(testFilter),
                         new Filter(),
                         Optional.of("params"))
         );
     }
 
-    @Test
-    public void testGetPropertyValueFilterWithUnavailableColumns() throws Exception {
+    @ParameterizedTest(name = "GetPropertyValue unavailable columns [{index}] {0}")
+    @MethodSource("filters")
+    void testGetPropertyValueFilterWithUnavailableColumns(String testName, String testFilter) throws Exception {
         handleUnavailableColumn(
-                get(getGetPropertyValueParams(),
+                get(getGetPropertyValueParams(testFilter),
                         new Filter(),
                         Optional.of("fullname"))
         );
     }
 
-    @Test
-    public void testGetPropertyValueFilterWithCollectionBasedColumnFiltering() throws Exception {
+    @ParameterizedTest(name = "GetPropertyValue collection based column filtering [{index}] {0}")
+    @MethodSource("filters")
+    void testGetPropertyValueFilterWithCollectionBasedColumnFiltering(String testName, String testFilter) throws Exception {
         handleOK(
-                get(getGetPropertyValueParams(),
+                get(getGetPropertyValueParams(testFilter),
                         new Filter(),
                         Optional.of(COLLECTION_NAME + ":params"))
         );
 
         handleUnavailableColumn(
-                get(getGetPropertyValueParams(),
+                get(getGetPropertyValueParams(testFilter),
                         new Filter(),
                         Optional.of("notExisting:params,fullname"))
         );
 
         handleUnavailableCollection(
-                get(getGetPropertyValueParams(),
+                get(getGetPropertyValueParams(testFilter),
                         new Filter(),
                         Optional.of("notExisting:params"))
         );
-
     }
 
-    private List<Pair<String, String>> getFeatureParams() {
+    private List<Pair<String, String>> getFeatureParams(String testFilter) {
         return Arrays.asList(
                 new ImmutablePair<>("SERVICE", "WFS"),
                 new ImmutablePair<>("VERSION", "2.0.0"),
@@ -160,7 +164,7 @@ public class WFSServiceWithOgcFilterIT extends AbstractWFSServiceTest {
                 new ImmutablePair<>("FILTER", testFilter));
     }
 
-    private List<Pair<String, String>> getGetPropertyValueParams() {
+    private List<Pair<String, String>> getGetPropertyValueParams(String testFilter) {
         return Arrays.asList(
                 new ImmutablePair<>("SERVICE", "WFS"),
                 new ImmutablePair<>("VERSION", "2.0.0"),
@@ -170,44 +174,48 @@ public class WFSServiceWithOgcFilterIT extends AbstractWFSServiceTest {
                 new ImmutablePair<>("FILTER", testFilter));
     }
 
-    @Parameterized.Parameters(name = "filter {index}: {0}")
-    public static Collection data() {
-        return Arrays.asList(new Object[][] {
-               {"PropertyIsEqualTo", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsEqualTo matchAction=\"Any\" " +
-                       "matchCase=\"true\"><ValueReference>params.hob</ValueReference><Literal>Architect</Literal></PropertyIsEqualTo></Filter>"},
-                {"PropertyIsLessThan", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsLessThan><ValueReference>params.age</ValueReference><Literal>3400</Literal></PropertyIsLessThan></Filter>"},
-                {"PropertyIsLessThanOrEqualTo", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsLessThanOrEqualTo><ValueReference>params.age</ValueReference><Literal>3400</Literal></PropertyIsLessThanOrEqualTo></Filter>"},
-                {"PropertyIsGreaterThan", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsGreaterThan><ValueReference>params.age</ValueReference><Literal>3400</Literal></PropertyIsGreaterThan></Filter>"},
-                {"PropertyIsGreaterThanOrEqualTo", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsGreaterThanOrEqualTo><ValueReference>params.age</ValueReference><Literal>3400</Literal></PropertyIsGreaterThanOrEqualTo></Filter>"},
-                {"PropertyIsLessThanOrEqualTo  AND PropertyIsEqualTo", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><And><PropertyIsEqualTo matchAction=\"Any\" " +
-                        "matchCase=\"true\"><ValueReference>id</ValueReference><Literal>ID__170__20DI</Literal></PropertyIsEqualTo><PropertyIsLessThanOrEqualTo><ValueReference>params" +
-                        ".age</ValueReference><Literal>3200</Literal></PropertyIsLessThanOrEqualTo></And></Filter>"},
-                {"PropertyIsLessThanOrEqualTo OR PropertyIsEqualTo", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><Or><PropertyIsEqualTo matchAction=\"Any\" " +
-                        "matchCase=\"true\"><ValueReference>id</ValueReference><Literal>ID__170__20DI</Literal></PropertyIsEqualTo><PropertyIsLessThanOrEqualTo><ValueReference>params" +
-                        ".age</ValueReference><Literal>3200</Literal></PropertyIsLessThanOrEqualTo></Or></Filter>"},
-                {"PropertyIsEqualTo OR (PropertyIsLessThanOrEqualTo AND PropertyIsGreaterThan", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><Or><PropertyIsEqualTo matchAction=\"Any\" " +
-                        "matchCase=\"true\"><ValueReference>id</ValueReference><Literal>ID__170__20DI</Literal></PropertyIsEqualTo><And><PropertyIsLessThanOrEqualTo><ValueReference>params" +
-                        ".age</ValueReference><Literal>3200</Literal></PropertyIsLessThanOrEqualTo><PropertyIsGreaterThan><ValueReference>params.age</ValueReference><Literal>3000</Literal></PropertyIsGreaterThan></And></Or></Filter>"},
-                {"PropertyIsBetween", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsBetween><ValueReference>params" +
-                        ".age</ValueReference><LowerBoundary><Literal>3000</Literal></LowerBoundary><UpperBoundary><Literal>3200</Literal></UpperBoundary></PropertyIsBetween></Filter>"},
-                {"PropertyIsEqualTo OR PropertyIsBetween", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><Or><PropertyIsEqualTo matchAction=\"Any\" " +
-                        "matchCase=\"true\"><ValueReference>id</ValueReference><Literal>ID__170__20DI</Literal></PropertyIsEqualTo><PropertyIsBetween><ValueReference>params" +
-                        ".age</ValueReference><LowerBoundary><Literal>3000</Literal></LowerBoundary><UpperBoundary><Literal>3200</Literal></UpperBoundary></PropertyIsBetween></Or></Filter>"},
-                {"Not PropertyIsEqual", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><Not><PropertyIsEqualTo matchAction=\"Any\" " +
-                        "matchCase=\"true\"><ValueReference>params.job</ValueReference><Literal>Architect</Literal></PropertyIsEqualTo></Not></Filter>"},
-                {"BinaryTemporalOperator", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\" xmlns:gml=\"http://www.opengis.net/gml/3.2\"><During><ValueReference>params.stopdate</ValueReference><gml:TimePeriod " +
-                        "gml:id=\"TP1\"><gml:begin><gml:TimeInstant gml:id=\"TI1\"><gml:timePosition>2005-05-17T00:00:00Z</gml:timePosition></gml:TimeInstant></gml:begin><gml:end><gml:TimeInstant " +
-                        "gml:id=\"TI2\"><gml:timePosition>2005-05-23T00:00:00Z</gml:timePosition></gml:TimeInstant></gml:end></gml:TimePeriod></During></Filter>"},
-                { "PropertyIsNull", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsNull matchAction=\"Any\" " +
-                        "matchCase=\"true\"><ValueReference>params.job</ValueReference><Literal>Architect</Literal></PropertyIsNull></Filter>"}
-//                {"BBOX - TODO fix BBOX it is not working at all in WFS project", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\" xmlns:gml=\"http://www.opengis.net/gml/3.2\"><BBOX><ValueReference>geo_params
-//                 .geometry</ValueReference><gml:Envelope srsName=\"http://www.opengis" +
-//                        ".net/def/crs/epsg/0/4326\"><gml:lowerCorner>13.0983 31.5899</gml:lowerCorner><gml:upperCorner>35.5472 42.8143</gml:upperCorner></gml:Envelope></BBOX></Filter>"},
-//                {"within - TODO fix WITHIN it is not working at all in WFS project", "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\" xmlns:gml=\"http://www.opengis.net/gml/3.2\"><Within><ValueReference>geo_params.geometry</ValueReference><gml:Polygon gml:id=\"P1\" " +
-//                        "srsName=\"http://www.opengis.net/def/crs/epsg/0/4326\"><gml:exterior><gml:LinearRing><gml:posList>10 10 20 20 30 30 40 40 10 " +
-//                        "10</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></Within></Filter>"},
-
-        });
+    static Stream<Arguments> filters() {
+        return Stream.of(
+                Arguments.of("PropertyIsEqualTo",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsEqualTo matchAction=\"Any\" " +
+                                "matchCase=\"true\"><ValueReference>params.hob</ValueReference><Literal>Architect</Literal></PropertyIsEqualTo></Filter>"),
+                Arguments.of("PropertyIsLessThan",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsLessThan><ValueReference>params.age</ValueReference><Literal>3400</Literal></PropertyIsLessThan></Filter>"),
+                Arguments.of("PropertyIsLessThanOrEqualTo",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsLessThanOrEqualTo><ValueReference>params.age</ValueReference><Literal>3400</Literal></PropertyIsLessThanOrEqualTo></Filter>"),
+                Arguments.of("PropertyIsGreaterThan",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsGreaterThan><ValueReference>params.age</ValueReference><Literal>3400</Literal></PropertyIsGreaterThan></Filter>"),
+                Arguments.of("PropertyIsGreaterThanOrEqualTo",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsGreaterThanOrEqualTo><ValueReference>params.age</ValueReference><Literal>3400</Literal></PropertyIsGreaterThanOrEqualTo></Filter>"),
+                Arguments.of("PropertyIsLessThanOrEqualTo AND PropertyIsEqualTo",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><And><PropertyIsEqualTo matchAction=\"Any\" " +
+                                "matchCase=\"true\"><ValueReference>id</ValueReference><Literal>ID__170__20DI</Literal></PropertyIsEqualTo><PropertyIsLessThanOrEqualTo><ValueReference>params" +
+                                ".age</ValueReference><Literal>3200</Literal></PropertyIsLessThanOrEqualTo></And></Filter>"),
+                Arguments.of("PropertyIsLessThanOrEqualTo OR PropertyIsEqualTo",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><Or><PropertyIsEqualTo matchAction=\"Any\" " +
+                                "matchCase=\"true\"><ValueReference>id</ValueReference><Literal>ID__170__20DI</Literal></PropertyIsEqualTo><PropertyIsLessThanOrEqualTo><ValueReference>params" +
+                                ".age</ValueReference><Literal>3200</Literal></PropertyIsLessThanOrEqualTo></Or></Filter>"),
+                Arguments.of("PropertyIsEqualTo OR (PropertyIsLessThanOrEqualTo AND PropertyIsGreaterThan)",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><Or><PropertyIsEqualTo matchAction=\"Any\" " +
+                                "matchCase=\"true\"><ValueReference>id</ValueReference><Literal>ID__170__20DI</Literal></PropertyIsEqualTo><And><PropertyIsLessThanOrEqualTo><ValueReference>params" +
+                                ".age</ValueReference><Literal>3200</Literal></PropertyIsLessThanOrEqualTo><PropertyIsGreaterThan><ValueReference>params.age</ValueReference><Literal>3000</Literal></PropertyIsGreaterThan></And></Or></Filter>"),
+                Arguments.of("PropertyIsBetween",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsBetween><ValueReference>params" +
+                                ".age</ValueReference><LowerBoundary><Literal>3000</Literal></LowerBoundary><UpperBoundary><Literal>3200</Literal></UpperBoundary></PropertyIsBetween></Filter>"),
+                Arguments.of("PropertyIsEqualTo OR PropertyIsBetween",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><Or><PropertyIsEqualTo matchAction=\"Any\" " +
+                                "matchCase=\"true\"><ValueReference>id</ValueReference><Literal>ID__170__20DI</Literal></PropertyIsEqualTo><PropertyIsBetween><ValueReference>params" +
+                                ".age</ValueReference><LowerBoundary><Literal>3000</Literal></LowerBoundary><UpperBoundary><Literal>3200</Literal></UpperBoundary></PropertyIsBetween></Or></Filter>"),
+                Arguments.of("Not PropertyIsEqual",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><Not><PropertyIsEqualTo matchAction=\"Any\" " +
+                                "matchCase=\"true\"><ValueReference>params.job</ValueReference><Literal>Architect</Literal></PropertyIsEqualTo></Not></Filter>"),
+                Arguments.of("BinaryTemporalOperator",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\" xmlns:gml=\"http://www.opengis.net/gml/3.2\"><During><ValueReference>params.stopdate</ValueReference><gml:TimePeriod " +
+                                "gml:id=\"TP1\"><gml:begin><gml:TimeInstant gml:id=\"TI1\"><gml:timePosition>2005-05-17T00:00:00Z</gml:timePosition></gml:TimeInstant></gml:begin><gml:end><gml:TimeInstant " +
+                                "gml:id=\"TI2\"><gml:timePosition>2005-05-23T00:00:00Z</gml:timePosition></gml:TimeInstant></gml:end></gml:TimePeriod></During></Filter>"),
+                Arguments.of("PropertyIsNull",
+                        "<Filter xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"><PropertyIsNull matchAction=\"Any\" " +
+                                "matchCase=\"true\"><ValueReference>params.job</ValueReference><Literal>Architect</Literal></PropertyIsNull></Filter>")
+        );
     }
-
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/CORSIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/CORSIT.java
@@ -20,7 +20,7 @@
 package io.arlas.server.tests.rest;
 
 import io.arlas.server.tests.AbstractTestContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/collections/CollectionServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/collections/CollectionServiceIT.java
@@ -24,9 +24,9 @@ import io.arlas.server.tests.AbstractTestWithCollection;
 import io.arlas.server.tests.DataSetTool;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -34,10 +34,10 @@ import java.util.stream.Collectors;
 import static io.arlas.commons.rest.utils.ServerConstants.ARLAS_ORGANISATION;
 import static io.arlas.commons.rest.utils.ServerConstants.COLUMN_FILTER;
 import static io.restassured.RestAssured.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class CollectionServiceIT extends AbstractTestWithCollection {
 
     @Test

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/ATOMSearchServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/ATOMSearchServiceIT.java
@@ -39,9 +39,9 @@ import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.XmlConfig.xmlConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Every.everyItem;
-import static org.junit.Assert.assertThat;
 
 public class ATOMSearchServiceIT extends AbstractProjectedTest {
 

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractAggregatedTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractAggregatedTest.java
@@ -25,9 +25,10 @@ import io.arlas.server.tests.DataSetTool;
 import io.dropwizard.jackson.JsonSnakeCase;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
+
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,7 +42,7 @@ public abstract class AbstractAggregatedTest extends AbstractFormattedTest {
     protected static AggregationsRequest aggregationRequest;
     protected static Aggregation aggregationModel;
 
-    @Before
+    @BeforeEach
     public void setUpAggregationRequest() {
         aggregationRequest = new AggregationsRequest();
         aggregationRequest.filter = new Filter();
@@ -201,7 +202,7 @@ public abstract class AbstractAggregatedTest extends AbstractFormattedTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     // Not testable without ES premium, so ignored for CI
     public void testGeohexAggregate() throws Exception {
         //GEOHEX

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractComputationTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractComputationTest.java
@@ -23,8 +23,9 @@ import io.arlas.server.core.model.enumerations.ComputationEnum;
 import io.arlas.server.core.model.enumerations.OperatorEnum;
 import io.arlas.server.core.model.request.*;
 import io.restassured.response.ValidatableResponse;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 import java.util.Arrays;
 
@@ -34,7 +35,7 @@ import static io.restassured.RestAssured.given;
 public abstract class AbstractComputationTest extends AbstractFilteredTest {
     protected static ComputationRequest computationRequest;
 
-    @Before
+    @BeforeEach
     public void setUpComputationRequest() {
         computationRequest = new ComputationRequest();
         computationRequest.filter = new Filter();

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractDescribeTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractDescribeTest.java
@@ -22,7 +22,7 @@ package io.arlas.server.tests.rest.explore;
 import io.arlas.server.tests.AbstractTestWithCollection;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.ValidatableResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractFilteredTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractFilteredTest.java
@@ -33,8 +33,8 @@ import io.restassured.specification.RequestSpecification;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.Matcher;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -48,7 +48,7 @@ import static org.hamcrest.Matchers.*;
 public abstract class AbstractFilteredTest extends AbstractTestWithCollection {
 
     private static ObjectMapper objectMapper = new ObjectMapper();
-    @Before
+    @BeforeEach
     public void setUpFilter() {
         request = new Request();
         request.filter = new Filter();

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractFormattedTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractFormattedTest.java
@@ -24,7 +24,7 @@ import io.arlas.server.core.model.request.Request;
 import static io.restassured.RestAssured.given;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractGeohashTiledTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractGeohashTiledTest.java
@@ -21,7 +21,7 @@ package io.arlas.server.tests.rest.explore;
 
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractPaginatedTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractPaginatedTest.java
@@ -29,18 +29,18 @@ import io.arlas.server.core.model.request.Page;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.notNullValue;
 import java.net.URLDecoder;
 import java.util.HashMap;
-import java.util.Optional;
 
 public abstract class AbstractPaginatedTest extends AbstractFormattedTest{
     protected static Search search = new Search();
 
-    @Before
+    @BeforeEach
     public void setUpSearch() {
         search.page = new Page();
         search.filter = new Filter();

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractProjectedTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractProjectedTest.java
@@ -26,15 +26,16 @@ import io.arlas.server.core.model.request.Request;
 import io.arlas.server.core.model.request.Page;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 import java.util.Arrays;
 import java.util.List;
 
 public abstract class AbstractProjectedTest extends AbstractPaginatedTest {
 
-    @Before
+    @BeforeEach
     public void setUpSearch() {
         search.page = new Page();
         search.filter = new Filter();

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractXYZTiledTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/AbstractXYZTiledTest.java
@@ -23,14 +23,14 @@ import io.arlas.server.core.model.enumerations.OperatorEnum;
 import io.arlas.server.core.model.request.*;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
 public abstract class AbstractXYZTiledTest extends AbstractProjectedTest {
-    @Before
+    @BeforeEach
     public void setUpSearch() {
         search.filter = new Filter();
         search.filter.righthand = false;

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/CountServiceNoExcludeIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/CountServiceNoExcludeIT.java
@@ -21,13 +21,13 @@ package io.arlas.server.tests.rest.explore;
 
 import io.arlas.commons.exceptions.ArlasException;
 import io.arlas.server.tests.CollectionTool;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 
 public class CountServiceNoExcludeIT extends CountServiceIT {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws ArlasException, IOException {
         new CollectionTool().load(10000, false, false, false);
     }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/DescribeServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/DescribeServiceIT.java
@@ -23,7 +23,7 @@ import io.arlas.server.tests.DataSetTool;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.ValidatableResponse;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/RawServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/RawServiceIT.java
@@ -22,7 +22,7 @@ package io.arlas.server.tests.rest.explore;
 import io.arlas.server.tests.AbstractTestWithCollection;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Optional;

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/opensearch/OpenSearchServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/explore/opensearch/OpenSearchServiceIT.java
@@ -25,7 +25,7 @@ import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.XmlConfig;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/arlas-tests/src/test/java/io/arlas/server/tests/rest/plugins/eo/TileServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/rest/plugins/eo/TileServiceIT.java
@@ -27,10 +27,10 @@ import jakarta.ws.rs.core.Response;
 import org.geojson.LngLatAlt;
 import org.geojson.Polygon;
 import org.hamcrest.Matchers;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -43,6 +43,7 @@ import java.util.stream.Stream;
 import static io.arlas.commons.rest.utils.ServerConstants.COLUMN_FILTER;
 import static io.arlas.server.tests.CollectionTool.COLLECTION_NAME;
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -52,7 +53,7 @@ public class TileServiceIT extends AbstractTestContext {
         return arlasPath + "explore/" + collection + "/_tile";
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws IOException, InterruptedException, ArlasException {
         AbstractTestWithCollection.beforeClass();
 
@@ -88,7 +89,7 @@ public class TileServiceIT extends AbstractTestContext {
         Thread.sleep(5000);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() throws IOException, ArlasException {
         AbstractTestWithCollection.afterClass();
     }
@@ -122,20 +123,20 @@ public class TileServiceIT extends AbstractTestContext {
                 givenTileQuery("f=id:eq:ID_0_10DI_bottom", Optional.empty())
                         .statusCode(Response.Status.OK.getStatusCode()).extract().asInputStream());
 
-        Assert.assertThat("image height is 256",
+        assertThat("image height is 256",
                 image.getHeight(),
                 Matchers.equalTo(256));
-        Assert.assertThat("image width is 256",
+        assertThat("image width is 256",
                 image.getWidth(),
                 Matchers.equalTo(256));
 
         int coverage = ImageUtil.coverage(image,10);
 
-        Assert.assertThat("coverage",
+        assertThat("coverage",
                 coverage,
                 greaterThan(40));
 
-        Assert.assertThat("coverage",
+        assertThat("coverage",
                 coverage,
                 lessThan(60));
 
@@ -145,18 +146,18 @@ public class TileServiceIT extends AbstractTestContext {
                         .statusCode(Response.Status.OK.getStatusCode()).extract().asInputStream());
         coverage = ImageUtil.coverage(image,10);
 
-        Assert.assertThat("image height is 256",
+        assertThat("image height is 256",
                 image.getHeight(),
                 Matchers.equalTo(256));
-        Assert.assertThat("image width is 256",
+        assertThat("image width is 256",
                 image.getWidth(),
                 Matchers.equalTo(256));
 
-        Assert.assertThat("coverage",
+        assertThat("coverage",
                 coverage,
                 greaterThan(40));
 
-        Assert.assertThat("coverage",
+        assertThat("coverage",
                 coverage,
                 lessThan(60));
 
@@ -165,16 +166,15 @@ public class TileServiceIT extends AbstractTestContext {
                 givenTileQuery("f=id:eq:ID_0_10DI_bottom,ID_0_10DI_top&coverage=70", Optional.empty())
                         .statusCode(Response.Status.OK.getStatusCode()).extract().asInputStream());
 
-        Assert.assertThat("image height is 256",
+        assertThat("image height is 256",
                 image.getHeight(),
                 Matchers.equalTo(256));
-        Assert.assertThat("image width is 256",
+        assertThat("image width is 256",
                 image.getWidth(),
                 Matchers.equalTo(256));
 
         coverage = ImageUtil.coverage(image,10);
-
-        Assert.assertThat("coverage",
+        assertThat("coverage",
                 coverage,
                 greaterThan(90));
     }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.arlas.commons.exceptions.InvalidParameterException;
+import io.arlas.server.core.model.request.Filter;
+import io.arlas.server.stac.model.SearchBody;
+import io.arlas.server.tests.AbstractTestWithCollection;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.params.provider.Arguments;
+import org.locationtech.jts.io.ParseException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static io.arlas.commons.rest.utils.ServerConstants.COLUMN_FILTER;
+import static io.arlas.commons.rest.utils.ServerConstants.PARTITION_FILTER;
+import static io.restassured.RestAssured.given;
+import static io.arlas.server.tests.stac.STACFilterModels.FilterLang;
+import static io.arlas.server.tests.stac.STACFilterModels.RequestTarget;
+import static io.arlas.server.tests.stac.STACFilterModels.StacFilterScenario;
+import static io.arlas.server.tests.stac.STACFilterModels.TypeOfGet;
+
+public class AbstractSTACServiceTest extends AbstractTestWithCollection {
+
+    public static final String COLLECTION = "geodata";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    protected final STACRequestFactory requestFactory = new STACRequestFactory(COLLECTION);
+    protected final STACResponseAssertions responseAssertions = new STACResponseAssertions();
+
+    public final List<String> arlasConformsTo = List.of(
+            "https://api.stacspec.org/v1.0.0/core",
+            "https://api.stacspec.org/v1.0.0-beta.2/core",
+            "https://api.stacspec.org/v1.0.0/item-search",
+            "https://api.stacspec.org/v1.0.0/ogcapi-features",
+            "https://api.stacspec.org/v1.0.0/collections",
+            "https://api.stacspec.org/v1.0.0/item-search#sort",
+            "https://api.stacspec.org/v1.0.0/item-search#context",
+            "https://api.stacspec.org/v1.0.0/item-search#filter",
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
+            "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
+            "http://www.opengis.net/spec/cql2/1.0/conf/cql2-json",
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions",
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions-plus"
+    );
+
+    @Override
+    protected String getUrlPath(String collection) {
+        return arlasPath + "stac/collections/" + collection + "/items";
+    }
+
+    protected String getUrlStacSearchPath() {
+        return arlasPath + "stac/search";
+    }
+
+    protected String getUrlStacPath() {
+        return arlasPath + "stac";
+    }
+
+    protected RequestSpecification givenFilterableRequestParams() {
+        return given().contentType("application/json;charset=utf-8");
+    }
+
+    protected ValidatableResponse get(
+            List<Pair<String, String>> params,
+            Filter headerFilter,
+            String columnFilter,
+            TypeOfGet typeOfGet
+    ) throws JsonProcessingException {
+        RequestSpecification req = givenFilterableRequestParams();
+
+        for (Pair<String, String> param : params) {
+            req = req.param(param.getKey(), param.getValue());
+        }
+
+        if (headerFilter != null) {
+            req = req.header(PARTITION_FILTER, OBJECT_MAPPER.writeValueAsString(headerFilter));
+        }
+
+        if (columnFilter != null) {
+            req = req.header(COLUMN_FILTER, columnFilter);
+        }
+
+        if (typeOfGet == TypeOfGet.OGC_FEATURE) {
+            return req.when().get(getUrlPath(COLLECTION)).then();
+        }
+        return req.when().get(getUrlStacSearchPath()).then();
+    }
+
+    protected ValidatableResponse post(
+            SearchBody<Object> body,
+            Filter headerFilter,
+            String columnFilter
+    ) throws JsonProcessingException {
+        RequestSpecification req = givenFilterableRequestParams();
+
+        if (headerFilter != null) {
+            req = req.header(PARTITION_FILTER, OBJECT_MAPPER.writeValueAsString(headerFilter));
+        }
+
+        if (columnFilter != null) {
+            req = req.header(COLUMN_FILTER, columnFilter);
+        }
+
+        return req.body(body).when().post(getUrlStacSearchPath()).then();
+    }
+
+    public static Stream<Arguments> scenarioCases(StacFilterScenario scenario) {
+        return Stream.of(
+                Arguments.of(label(scenario, RequestTarget.stacGet(), FilterLang.CQL2_TEXT), scenario, RequestTarget.stacGet(), FilterLang.CQL2_TEXT),
+                Arguments.of(label(scenario, RequestTarget.stacGet(), FilterLang.CQL2_JSON), scenario, RequestTarget.stacGet(), FilterLang.CQL2_JSON),
+                Arguments.of(label(scenario, RequestTarget.ogcGet(), FilterLang.CQL2_TEXT), scenario, RequestTarget.ogcGet(), FilterLang.CQL2_TEXT),
+                Arguments.of(label(scenario, RequestTarget.ogcGet(), FilterLang.CQL2_JSON), scenario, RequestTarget.ogcGet(), FilterLang.CQL2_JSON),
+                Arguments.of(label(scenario, RequestTarget.post(), FilterLang.CQL2_TEXT), scenario, RequestTarget.post(), FilterLang.CQL2_TEXT),
+                Arguments.of(label(scenario, RequestTarget.post(), FilterLang.CQL2_JSON), scenario, RequestTarget.post(), FilterLang.CQL2_JSON)
+        );
+    }
+
+    public static String label(StacFilterScenario scenario, RequestTarget target, FilterLang lang) {
+        String filterLabel = scenario.clauses().stream()
+                .map(c -> "%s %s %s".formatted(c.property(), c.operator().symbol(), c.value()))
+                .reduce((a, b) -> a + " AND " + b)
+                .orElse("");
+
+        String extras = "";
+        if (scenario.partitionFilter() != null || scenario.columnFilter() != null
+                || scenario.ids() != null || scenario.datetime() != null || scenario.bbox() != null) {
+            extras = " | partitionFilter=%s | columnFilter=%s | ids=%s | datetime=%s | bbox=%s"
+                    .formatted(
+                            scenario.partitionFilter() != null ? scenario.partitionFilter().f.toString() : null,
+                            scenario.columnFilter(),
+                            scenario.ids(),
+                            scenario.datetime(),
+                            scenario.bbox()
+                    );
+        }
+
+        return "%s | %s | filter=%s | limit=%d%s"
+                .formatted(target, lang.value(), filterLabel, scenario.limit(), extras);
+    }
+
+    public ValidatableResponse executeRequest(
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang
+    ) throws IOException, InvalidParameterException, ParseException {
+        return switch (target.mode()) {
+            case GET -> get(
+                    requestFactory.buildGetParams(scenario, lang),
+                    scenario.partitionFilter(),
+                    scenario.columnFilter(),
+                    target.typeOfGet()
+            );
+            case POST -> post(
+                    requestFactory.buildSearchBody(scenario, lang),
+                    scenario.partitionFilter(),
+                    scenario.columnFilter()
+            );
+        };
+    }
+
+    protected void assertCommonResponse(
+            ValidatableResponse response,
+            StacFilterScenario scenario,
+            RequestTarget target
+    ) {
+        responseAssertions.assertCommonResponse(response, scenario.expectedMatched(), target);
+    }
+
+    protected void assertReturnedValues(
+            ValidatableResponse response,
+            StacFilterScenario scenario
+    ) {
+        responseAssertions.assertClauses(response, scenario.clauses());
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceTest.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.arlas.commons.exceptions.InvalidParameterException;
 import io.arlas.server.core.model.request.Filter;
 import io.arlas.server.stac.model.SearchBody;
-import io.arlas.server.tests.AbstractTestWithCollection;
+import io.arlas.server.tests.AbstractTestContext;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.apache.commons.lang3.tuple.Pair;
@@ -43,7 +43,7 @@ import static io.arlas.server.tests.stac.STACFilterModels.RequestTarget;
 import static io.arlas.server.tests.stac.STACFilterModels.StacFilterScenario;
 import static io.arlas.server.tests.stac.STACFilterModels.TypeOfGet;
 
-public class AbstractSTACServiceTest extends AbstractTestWithCollection {
+public class AbstractSTACServiceTest extends AbstractTestContext {
 
     public static final String COLLECTION = "geodata";
 

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACFilterModels.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACFilterModels.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import io.arlas.server.core.model.request.Filter;
+
+import java.util.List;
+
+public final class STACFilterModels {
+
+    public enum TypeOfGet {
+        STAC, OGC_FEATURE
+    }
+
+    public enum HttpMethod {
+        GET, POST
+    }
+
+    public enum FilterOperator {
+        EQ("="),
+        NE("<>"),
+        GT(">"),
+        GTE(">="),
+        LT("<"),
+        LTE("<="),
+        BETWEEN("between"),
+        LIKE("like"),
+        ST_INTERSECTS("s_intersects"),
+        ST_WITHIN("s_within"),
+        BBOX("bbox");
+        private final String symbol;
+
+        FilterOperator(String symbol) {
+            this.symbol = symbol;
+        }
+
+        public String symbol() {
+            return symbol;
+        }
+    }
+
+    public record FilterClause(
+            String property,
+            FilterOperator operator,
+            Object value
+    ) {
+    }
+
+    public record RequestTarget(
+            HttpMethod mode,
+            TypeOfGet typeOfGet
+    ) {
+        public static RequestTarget stacGet() {
+            return new RequestTarget(HttpMethod.GET, TypeOfGet.STAC);
+        }
+
+        public static RequestTarget ogcGet() {
+            return new RequestTarget(HttpMethod.GET, TypeOfGet.OGC_FEATURE);
+        }
+
+        public static RequestTarget post() {
+            return new RequestTarget(HttpMethod.POST, null);
+        }
+
+        @Override
+        public String toString() {
+            return switch (mode) {
+                case GET -> "GET " + typeOfGet;
+                case POST -> "POST";
+            };
+        }
+    }
+
+    public enum FilterLang {
+        CQL2_TEXT("cql2-text"),
+        CQL2_JSON("cql2-json");
+
+        private final String value;
+
+        FilterLang(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+    }
+
+    public record StacFilterScenario(
+            List<FilterClause> clauses,
+            int limit,
+            int expectedMatched,
+            Filter partitionFilter,
+            String columnFilter,
+            List<String> ids,
+            String datetime,
+            String bbox
+    ) {
+        public static StacFilterScenario simple(
+                String property,
+                FilterOperator operator,
+                Object value,
+                int limit,
+                int expectedMatched
+        ) {
+            return new StacFilterScenario(
+                    List.of(new FilterClause(property, operator, value)),
+                    limit,
+                    expectedMatched,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+        }
+
+        public static StacFilterScenario and(
+                List<FilterClause> clauses,
+                int limit,
+                int expectedMatched
+        ) {
+            return new StacFilterScenario(
+                    clauses,
+                    limit,
+                    expectedMatched,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+        }
+
+        public StacFilterScenario withPartitionFilter(Filter partitionFilter) {
+            return new StacFilterScenario(
+                    clauses, limit, expectedMatched, partitionFilter, columnFilter, ids, datetime, bbox
+            );
+        }
+
+        public StacFilterScenario withColumnFilter(String columnFilter) {
+            return new StacFilterScenario(
+                    clauses, limit, expectedMatched, partitionFilter, columnFilter, ids, datetime, bbox
+            );
+        }
+
+        public StacFilterScenario withIds(List<String> ids) {
+            return new StacFilterScenario(
+                    clauses, limit, expectedMatched, partitionFilter, columnFilter, ids, datetime, bbox
+            );
+        }
+
+        public StacFilterScenario withDatetime(String datetime) {
+            return new StacFilterScenario(
+                    clauses, limit, expectedMatched, partitionFilter, columnFilter, ids, datetime, bbox
+            );
+        }
+
+        public StacFilterScenario withBbox(String bbox) {
+            return new StacFilterScenario(
+                    clauses, limit, expectedMatched, partitionFilter, columnFilter, ids, datetime, bbox
+            );
+        }
+    }
+
+    public record BetweenValue(
+            Object lower,
+            Object upper
+    ) { }
+
+    record BboxValue(
+            double minX,
+            double minY,
+            double maxX,
+            double maxY
+    ) { }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACFilterSerializer.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACFilterSerializer.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import org.geotools.geojson.geom.GeometryJSON;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.arlas.server.tests.stac.STACFilterModels.FilterClause;
+import static io.arlas.server.tests.stac.STACFilterModels.FilterLang;
+import static io.arlas.server.tests.stac.STACFilterModels.BetweenValue;
+import static io.arlas.server.tests.stac.STACFilterModels.BboxValue;
+
+import java.io.StringWriter;
+public class STACFilterSerializer {
+
+    public String serialize(List<FilterClause> clauses, FilterLang lang) throws ParseException, IOException {
+        return switch (lang) {
+            case CQL2_TEXT -> serializeText(clauses);
+            case CQL2_JSON -> serializeJson(clauses);
+        };
+    }
+
+    private String serializeText(List<FilterClause> clauses) {
+        return clauses.stream()
+                .map(this::serializeClauseToText)
+                .collect(Collectors.joining(" AND "));
+    }
+
+    private String serializeJson(List<FilterClause> clauses) throws ParseException, IOException {
+        if (clauses.size() == 1) {
+            return serializeClauseToJson(clauses.get(0));
+        }
+        String args = clauses.stream()
+                .map(this::serializeClauseToJsonUnchecked)
+                .collect(Collectors.joining(","));
+
+        return """
+               {"op":"and","args":[%s]}
+               """.formatted(args)
+                .replace("\n", "")
+                .trim();
+    }
+
+    private String serializeClauseToJsonUnchecked(FilterClause clause) {
+        try {
+            return serializeClauseToJson(clause);
+        } catch (ParseException | IOException e) {
+            throw new IllegalStateException("Unable to serialize clause: " + clause, e);
+        }
+    }
+
+    private String serializeClauseToText(FilterClause clause) {
+        return switch (clause.operator()) {
+            case BETWEEN -> {
+                BetweenValue between = asBetweenValue(clause);
+                yield "%s BETWEEN %s AND %s".formatted(
+                        clause.property(),
+                        toCqlTextLiteral(between.lower()),
+                        toCqlTextLiteral(between.upper())
+                );
+            }
+            case ST_INTERSECTS -> "S_INTERSECTS(%s,%s)".formatted(
+                    clause.property(),
+                    toCqlSpatialArgument(clause.value())
+            );
+            case ST_WITHIN -> "S_WITHIN(%s,%s)".formatted(
+                        clause.property(),
+                        toCqlSpatialArgument(clause.value())
+            );
+            case BBOX -> {
+                BboxValue bbox = asBboxValue(clause.value(), "BBOX");
+                yield "S_INTERSECTS(%s,%s)".formatted(
+                        clause.property(),
+                        toCqlBboxLiteral(bbox)
+                );
+            }
+            default -> "%s %s %s".formatted(
+                    clause.property(),
+                    clause.operator().symbol(),
+                    toCqlTextLiteral(clause.value())
+            );
+        };
+    }
+
+    private  String serializeClauseToJson(FilterClause clause) throws ParseException, IOException {
+        return switch (clause.operator()) {
+            case BETWEEN -> {
+                BetweenValue between = asBetweenValue(clause);
+                yield """
+                {"op":"between","args":[{"property":"%s"},%s,%s]}
+                """.formatted(
+                        clause.property(),
+                        toJsonLiteral(between.lower()),
+                        toJsonLiteral(between.upper())
+                ).replace("\n", "").trim();
+            }
+            case ST_INTERSECTS -> """
+            {"op":"s_intersects","args":[{"property":"%s"},%s]}
+            """.formatted(
+                    clause.property(),
+                    toJsonSpatialArgument(clause.value())
+            ).replace("\n", "").trim();
+
+            case ST_WITHIN -> """
+            {"op":"s_within","args":[{"property":"%s"},%s]}
+            """.formatted(
+                    clause.property(),
+                    toJsonSpatialArgument(clause.value())
+            ).replace("\n", "").trim();
+
+            case BBOX -> {
+                BboxValue bbox = asBboxValue(clause.value(), "BBOX");
+                yield """
+                {"op":"s_intersects","args":[{"property":"%s"},%s]}
+                """.formatted(
+                        clause.property(),
+                        toJsonBboxLiteral(bbox)
+                ).replace("\n", "").trim();
+            }
+            default -> """
+            {"op":"%s","args":[{"property":"%s"},%s]}
+            """.formatted(
+                    clause.operator().symbol(),
+                    clause.property(),
+                    toJsonLiteral(clause.value())
+            ).replace("\n", "").trim();
+        };
+    }
+
+    private String toJsonLiteral(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof String s) {
+            return "\"" + s
+                    .replace("\\", "\\\\")
+                    .replace("\"", "\\\"") + "\"";
+        }
+        return String.valueOf(value);
+    }
+
+    private String toCqlTextLiteral(Object value) {
+        if (value instanceof String) {
+            return "'" + escapeCqlText(value) + "'";
+        }
+        return escapeCqlText(value);
+    }
+
+    private String escapeCqlText(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof String s) {
+            return s.replace("'", "''");
+        }
+        return String.valueOf(value);
+    }
+
+    private BetweenValue asBetweenValue(FilterClause clause) {
+        if (clause.value() instanceof BetweenValue between) {
+            return between;
+        }
+        throw new IllegalArgumentException(
+                "BETWEEN operator requires a BetweenValue for property: " + clause.property()
+        );
+    }
+
+    private String toCqlSpatialArgument(Object value) {
+        if (value instanceof BboxValue bbox) {
+            return toCqlBboxLiteral(bbox);
+        }
+        return toCqlTextLiteral(value);
+    }
+
+    private String toCqlBboxLiteral(BboxValue bbox) {
+        return "BBOX(%s,%s,%s,%s)".formatted(
+                bbox.minX(),
+                bbox.minY(),
+                bbox.maxX(),
+                bbox.maxY()
+        );
+    }
+    private String toJsonBboxLiteral(BboxValue bbox) {
+        return """
+        {"type":"Polygon","coordinates":[[
+          [%s,%s],
+          [%s,%s],
+          [%s,%s],
+          [%s,%s],
+          [%s,%s]
+        ]]}
+        """.formatted(
+                bbox.minX(), bbox.minY(),
+                bbox.maxX(), bbox.minY(),
+                bbox.maxX(), bbox.maxY(),
+                bbox.minX(), bbox.maxY(),
+                bbox.minX(), bbox.minY()
+        ).replaceAll("\\s+", "");
+    }
+
+    private BboxValue asBboxValue(Object value, String operator) {
+        if (value instanceof BboxValue bbox) {
+            return bbox;
+        }
+        throw new IllegalArgumentException(operator + " requires a BboxValue");
+    }
+
+    private String toJsonSpatialArgument(Object value) throws ParseException, IOException {
+        if (value instanceof BboxValue bbox) {
+            return toJsonBboxLiteral(bbox);
+        }
+        if (value instanceof String s && looksLikeWkt(s)) {
+            return wktToGeoJsonLiteral(s);
+        }
+        return toJsonLiteral(value);
+    }
+
+    private static boolean looksLikeWkt(String value) {
+        String trimmed = value == null ? "" : value.trim().toUpperCase();
+        return trimmed.startsWith("POINT")
+                || trimmed.startsWith("LINESTRING")
+                || trimmed.startsWith("POLYGON")
+                || trimmed.startsWith("MULTIPOINT")
+                || trimmed.startsWith("MULTILINESTRING")
+                || trimmed.startsWith("MULTIPOLYGON")
+                || trimmed.startsWith("GEOMETRYCOLLECTION");
+    }
+
+    private static String wktToGeoJsonLiteral(String wkt) throws ParseException, IOException {
+        WKTReader reader = new WKTReader();
+        Geometry geometry = reader.read(wkt);
+        GeometryJSON geometryJson = new GeometryJSON();
+        StringWriter writer = new StringWriter();
+        geometryJson.write(geometry, writer);
+        return writer.toString();
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACRequestFactory.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACRequestFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import io.arlas.commons.exceptions.InvalidParameterException;
+import io.arlas.server.stac.model.SearchBody;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.locationtech.jts.io.ParseException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static io.arlas.server.tests.stac.STACFilterModels.FilterLang;
+import static io.arlas.server.tests.stac.STACFilterModels.StacFilterScenario;
+
+public class STACRequestFactory {
+
+    private final String collection;
+    private final STACFilterSerializer serializer = new STACFilterSerializer();
+
+    public STACRequestFactory(String collection) {
+        this.collection = collection;
+    }
+
+    public List<Pair<String, String>> buildGetParams(
+            StacFilterScenario scenario,
+            FilterLang lang
+    ) throws ParseException, IOException {
+        List<Pair<String, String>> params = new ArrayList<>();
+        params.add(new ImmutablePair<>("collections", collection));
+        params.add(new ImmutablePair<>("filter", serializer.serialize(scenario.clauses(), lang)));
+        params.add(new ImmutablePair<>("limit", String.valueOf(scenario.limit())));
+        params.add(new ImmutablePair<>("filter-lang", lang.value()));
+
+        if (scenario.bbox() != null) {
+            params.add(new ImmutablePair<>("bbox", scenario.bbox()));
+        }
+
+        if (scenario.datetime() != null) {
+            params.add(new ImmutablePair<>("datetime", scenario.datetime()));
+        }
+
+        if (scenario.ids() != null) {
+            scenario.ids().forEach(id -> params.add(new ImmutablePair<>("ids", id)));
+        }
+
+        return params;
+    }
+
+    public SearchBody<Object> buildSearchBody(
+            StacFilterScenario scenario,
+            FilterLang lang
+    ) throws InvalidParameterException, ParseException, IOException {
+        SearchBody<Object> body = new SearchBody<>()
+                .filterLang(lang.value())
+                .collections(List.of(collection))
+                .limit(scenario.limit())
+                .filter(serializer.serialize(scenario.clauses(), lang));
+
+        if (scenario.bbox() != null) {
+            body.bbox(parseBbox(scenario.bbox()));
+        }
+
+        if (scenario.datetime() != null) {
+            body.datetime(scenario.datetime());
+        }
+
+        if (scenario.ids() != null) {
+            body.ids(scenario.ids());
+        }
+
+        return body;
+    }
+
+    private List<Double> parseBbox(String bbox) throws InvalidParameterException {
+        try {
+            return Stream.of(bbox.split(","))
+                    .map(Double::valueOf)
+                    .toList();
+        } catch (NumberFormatException e) {
+            throw new InvalidParameterException("Invalid bbox definition: " + bbox);
+        }
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACResponseAssertions.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACResponseAssertions.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+
+import static io.arlas.server.tests.stac.STACFilterModels.FilterClause;
+import static io.arlas.server.tests.stac.STACFilterModels.RequestTarget;
+import static io.arlas.server.tests.stac.STACFilterModels.TypeOfGet;
+import static org.hamcrest.Matchers.*;
+
+public class STACResponseAssertions {
+
+    public void assertCommonResponse(
+            ValidatableResponse response,
+            int expectedMatched,
+            RequestTarget target
+    ) {
+        String propertyPath = target.typeOfGet() == TypeOfGet.OGC_FEATURE
+                ? "numberMatched"
+                : "context.matched";
+
+        response
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(propertyPath, equalTo(expectedMatched));
+    }
+
+    public void assertClauses(
+            ValidatableResponse response,
+            List<FilterClause> clauses
+    ) {
+        for (FilterClause clause : clauses) {
+            assertClause(response, clause);
+        }
+    }
+
+    private void assertClause(
+            ValidatableResponse response,
+            FilterClause clause
+    ) {
+        String path = "features.properties." + clause.property();
+
+        switch (clause.operator()) {
+            case EQ -> response.body(path, everyItem(equalTo(clause.value())));
+            case NE -> response.body(path, everyItem(not(equalTo(clause.value()))));
+            case GT -> response.body(path, everyItem(greaterThanValue(clause.value())));
+            case GTE -> response.body(path, everyItem(greaterThanOrEqualToValue(clause.value())));
+            case LT -> response.body(path, everyItem(lessThanValue(clause.value())));
+            case LTE -> response.body(path, everyItem(lessThanOrEqualToValue(clause.value())));
+            case LIKE -> response.body(path, everyItem(containsString(String.valueOf(clause.value()))));
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Matcher greaterThanValue(Object value) {
+        return (Matcher) greaterThan((Comparable) value);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Matcher greaterThanOrEqualToValue(Object value) {
+        return (Matcher) greaterThanOrEqualTo((Comparable) value);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Matcher lessThanValue(Object value) {
+        return (Matcher) lessThan((Comparable) value);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Matcher lessThanOrEqualToValue(Object value) {
+        return (Matcher) lessThanOrEqualTo((Comparable) value);
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceAndFilterIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceAndFilterIT.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import io.arlas.server.tests.stac.STACFilterModels.StacFilterScenario;
+import io.arlas.server.tests.stac.STACFilterModels.RequestTarget;
+import io.arlas.server.tests.stac.STACFilterModels.FilterLang;
+import io.arlas.server.tests.stac.STACFilterModels.FilterOperator;
+import io.arlas.server.tests.stac.STACFilterModels.FilterClause;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class STACServiceAndFilterIT extends AbstractSTACServiceTest {
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("andFilterCases")
+    public void testAndFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario, target);
+        assertReturnedValues(response, scenario);
+    }
+
+    static Stream<Arguments> andFilterCases() {
+        return Stream.of(
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Actor"),
+                                new FilterClause("params.age", FilterOperator.EQ, 0),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1000000)),
+                        600, 1
+                )),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Actor"),
+                                new FilterClause("params.age", FilterOperator.GTE, 0),
+                                new FilterClause("params.startdate", FilterOperator.LTE, 1000000)),
+                        600, 31
+
+                )),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Chemist"),
+                                new FilterClause("params.age", FilterOperator.EQ, 600),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1050600)),
+                        600, 2
+                )),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Coder"),
+                                new FilterClause("params.age", FilterOperator.EQ, 1000),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1071000)),
+                        600, 2
+                )),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Brain Scientist"),
+                                new FilterClause("params.age", FilterOperator.EQ, 400),
+                                new FilterClause("params.startdate", FilterOperator.GTE, 1040000)),
+                        600, 1
+                )),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.NE, "Actor"),
+                                new FilterClause("params.age", FilterOperator.LT, 7000),
+                                new FilterClause("params.startdate", FilterOperator.GT, 950000)),
+                        600, 291
+
+                )),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.GTE, "Chemist"),
+                                new FilterClause("params.age", FilterOperator.LTE, 2600),
+                                new FilterClause("params.startdate", FilterOperator.GTE, 1020000)),
+                        600, 70
+
+                )),
+
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.LTE, "Dancer"),
+                                new FilterClause("params.age", FilterOperator.GT, 0),
+                                new FilterClause("params.startdate", FilterOperator.LT, 1100000)),
+                        600, 424
+
+                ))
+        ).flatMap(s -> s);
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceBasicFilterIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceBasicFilterIT.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import io.arlas.server.tests.stac.STACFilterModels.StacFilterScenario;
+import io.arlas.server.tests.stac.STACFilterModels.RequestTarget;
+import io.arlas.server.tests.stac.STACFilterModels.FilterLang;
+import io.arlas.server.tests.stac.STACFilterModels.FilterOperator;
+import io.arlas.server.tests.stac.STACFilterModels.BetweenValue;
+import java.util.stream.Stream;
+
+public class STACServiceBasicFilterIT extends AbstractSTACServiceTest {
+
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("filterStringCases")
+    public void testStringBasicFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang
+    ) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario,target);
+        assertReturnedValues(response, scenario);
+    }
+
+    static Stream<Arguments> filterStringCases() {
+        return Stream.of(
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.EQ, "Actor", 60, 59)),
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.NE, "Actor", 60, 536)),
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.GT, "Actor", 600, 536)),
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.GTE, "Actor", 600, 595)),
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.LT, "Actor", 60, 0)),
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.LTE, "Actor", 60, 59)),
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.LIKE, "cto", 60, 59)),
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.BETWEEN, new BetweenValue("Architect","Dancer"), 600, 420))
+        ).flatMap(s -> s);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("filterErrorCases")
+    public void testLikeErrorFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang
+    ) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        response.assertThat().statusCode(400);
+
+    }
+    static Stream<Arguments> filterErrorCases() {
+        return Stream.of(
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.LIKE, "%cto", 60, 59))
+        ).flatMap(s -> s);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("filterLikeEscapeCases")
+    public void testLikeEscapeFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang
+    ) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        response.assertThat().statusCode(200);
+
+    }
+    static Stream<Arguments> filterLikeEscapeCases() {
+        return Stream.of(
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.LIKE, "\\%cto", 60, 59))
+        ).flatMap(s -> s);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("filterNumberCases")
+    public void testNumberFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang
+    ) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario, target);
+        assertReturnedValues(response, scenario);
+    }
+
+    static Stream<Arguments> filterNumberCases() {
+        return Stream.of(
+                scenarioCases(StacFilterScenario.simple("params.age", FilterOperator.EQ, 13600, 5, 4)),
+                scenarioCases(StacFilterScenario.simple("params.age", FilterOperator.NE, 13600, 600, 591)),
+                scenarioCases(StacFilterScenario.simple("params.age", FilterOperator.GT, 13600, 5, 0)),
+                scenarioCases(StacFilterScenario.simple("params.age", FilterOperator.GTE, 13600, 5, 4)),
+                scenarioCases(StacFilterScenario.simple("params.age", FilterOperator.LT, 13600, 600, 591)),
+                scenarioCases(StacFilterScenario.simple("params.age", FilterOperator.LTE, 13600, 600, 595)),
+                scenarioCases(StacFilterScenario.simple("params.age", FilterOperator.BETWEEN, new BetweenValue(10000, 50000), 600, 36))
+        ).flatMap(s -> s);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("filterDateCases")
+    public void testDateBasicFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang
+    ) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario, target);
+        assertReturnedValues(response, scenario);
+
+    }
+
+    static Stream<Arguments> filterDateCases() {
+        return Stream.of(
+                scenarioCases(StacFilterScenario.simple("params.startdate", FilterOperator.EQ, 1000000, 600, 1)),
+                scenarioCases(StacFilterScenario.simple("params.startdate", FilterOperator.NE, 1000000, 600, 594)),
+                scenarioCases(StacFilterScenario.simple("params.startdate", FilterOperator.GT, 1000000, 600, 289)),
+                scenarioCases(StacFilterScenario.simple("params.startdate", FilterOperator.GTE, 1000000, 600, 290)),
+                scenarioCases(StacFilterScenario.simple("params.startdate", FilterOperator.LT, 1000000, 600, 305)),
+                scenarioCases(StacFilterScenario.simple("params.startdate", FilterOperator.LTE, 1000000, 600, 306))
+        ).flatMap(s -> s);
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceFullFilterIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceFullFilterIT.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import io.arlas.server.tests.stac.STACFilterModels.StacFilterScenario;
+import io.arlas.server.tests.stac.STACFilterModels.RequestTarget;
+import io.arlas.server.tests.stac.STACFilterModels.FilterLang;
+import io.arlas.server.tests.stac.STACFilterModels.FilterOperator;
+import io.arlas.server.tests.stac.STACFilterModels.FilterClause;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class STACServiceFullFilterIT extends AbstractSTACServiceTest {
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("fullFilterCases")
+    public void testFullFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario, target);
+        assertReturnedValues(response, scenario);
+    }
+
+    static Stream<Arguments> fullFilterCases() {
+        return Stream.of(
+                scenarioCasesForGetID(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Actor"),
+                                new FilterClause("params.age", FilterOperator.EQ, 0),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1000000)),
+                        600, 0
+                ).withIds(List.of("FAKE_ID"))),
+                scenarioCasesForGetID(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Actor"),
+                                new FilterClause("params.age", FilterOperator.GTE, 0),
+                                new FilterClause("params.startdate", FilterOperator.LTE, 1000000)),
+                        600, 2
+
+                ).withIds(List.of("ID__170_30DI","ID__160__40DI"))),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Chemist"),
+                                new FilterClause("params.age", FilterOperator.EQ, 600),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1050600)),
+                        600, 2
+                ).withBbox("-50,-50,50,50")),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.LTE, "Dancer"),
+                                new FilterClause("params.age", FilterOperator.GT, 0),
+                                new FilterClause("params.startdate", FilterOperator.LT, 1100000)),
+                        600, 0
+
+                ).withDatetime("2018-02-12T00:00:00Z/2018-03-18T12:31:12Z")),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.LTE, "Dancer"),
+                                new FilterClause("params.age", FilterOperator.GT, 0),
+                                new FilterClause("params.startdate", FilterOperator.LT, 1100000)),
+                        600, 54
+
+                ).withDatetime("1970-01-01T00:12:43.600Z/1970-01-01T00:14:06.600Z"))
+        ).flatMap(s -> s);
+    }
+
+    // OGC-Feature Get with ID is not supported by specification, so we only test STAC with ID
+    public static Stream<Arguments> scenarioCasesForGetID(StacFilterScenario scenario) {
+        return Stream.of(
+                Arguments.of(label(scenario, RequestTarget.stacGet(), FilterLang.CQL2_TEXT), scenario, RequestTarget.stacGet(), FilterLang.CQL2_TEXT),
+                Arguments.of(label(scenario, RequestTarget.stacGet(), FilterLang.CQL2_JSON), scenario, RequestTarget.stacGet(), FilterLang.CQL2_JSON),
+                Arguments.of(label(scenario, RequestTarget.post(), FilterLang.CQL2_TEXT), scenario, RequestTarget.post(), FilterLang.CQL2_TEXT),
+                Arguments.of(label(scenario, RequestTarget.post(), FilterLang.CQL2_JSON), scenario, RequestTarget.post(), FilterLang.CQL2_JSON)
+        );
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceGeoFilterIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceGeoFilterIT.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import io.restassured.response.ValidatableResponse;
+import io.arlas.server.tests.stac.STACFilterModels.StacFilterScenario;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+
+import java.util.stream.Stream;
+
+public class STACServiceGeoFilterIT extends  AbstractSTACServiceTest {
+
+    public final static String POINT = "POINT(-151.00000005215406 80.9999999916181)";
+    public final static String LINESTRING = "LINESTRING(-89.123456 12.345678, 45.678901 -34.567890, 120.123456 67.890123)";
+    public final static String POLYGON = "POLYGON((-98.345678 15.234567, -98.345678 35.234567, -78.345678 35.234567, -78.345678 15.234567, -98.345678 15.234567))";
+    public final static String MULTIPOINT = "MULTIPOINT(-123.456789 -45.678901, 67.890123 78.901234, 10.123456 -10.123456)";
+    public final static String MULTILINESTRING = "MULTILINESTRING((-50.123456 20.345678, 30.456789 -15.678901, 90.789012 55.012345), (-70.345678 -25.456789, 15.678901 40.789012, 110.012345 -5.123456))";
+    public final static String MULTIPOLYGON = "MULTIPOLYGON(((-30.123456 10.234567, -30.123456 20.234567, -20.123456 20.234567, -20.123456 10.234567, -30.123456 10.234567)), ((50.456789 -30.567890, 50.456789 -25.567890, 55.456789 -25.567890, 55.456789 -30.567890, 50.456789 -30.567890)))";
+    public final static String VALID_GEOMETRYCOLLECTION = "GEOMETRYCOLLECTION(POINT(15.678901 -25.345678), POLYGON((-40.123456 15.234567, -40.123456 25.234567, -30.123456 25.234567, -30.123456 15.234567, -40.123456 15.234567)))";
+    public final static String INVALID_GEOMETRYCOLLECTION = "GEOMETRYCOLLECTION(POINT(15.678901 -25.345678), LINESTRING(-89.123456 12.345678, 45.678901 -34.567890, 120.123456 67.890123), POLYGON((-40.123456 15.234567, -40.123456 25.234567, -30.123456 25.234567, -30.123456 15.234567, -40.123456 15.234567)))";
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("withinFilterCases")
+    public void testGeoFilter(
+            String label,
+            STACFilterModels.StacFilterScenario scenario,
+            STACFilterModels.RequestTarget target,
+            STACFilterModels.FilterLang lang) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario, target);
+    }
+
+    static Stream<Arguments> withinFilterCases() {
+        return Stream.of(
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_WITHIN, "POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))", 600, 0)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_INTERSECTS, "POLYGON((-2 -2, 2 -2, 2 2, -2 2, -2 -2))", 600, 1)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.BBOX, new STACFilterModels.BboxValue(-2,-2,2,2), 600, 1)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.BBOX, new STACFilterModels.BboxValue(-2,-2,2,2), 600, 1).withBbox("-50,-50,50,50")),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_WITHIN, POINT, 600, 0)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_INTERSECTS, POINT, 600, 1)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_WITHIN, MULTIPOINT, 600, 0)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_INTERSECTS, MULTIPOINT, 600, 1)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_INTERSECTS, LINESTRING, 600, 7)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_INTERSECTS, MULTILINESTRING, 600, 12)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_WITHIN, POLYGON, 600, 64)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_INTERSECTS, POLYGON, 600, 66)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_WITHIN, MULTIPOLYGON, 600, 0)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_INTERSECTS, MULTIPOLYGON, 600, 105)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_WITHIN, VALID_GEOMETRYCOLLECTION, 600, 0)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_INTERSECTS, VALID_GEOMETRYCOLLECTION, 600, 2))
+        ).flatMap(s -> s);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("withinFilterErrorCases")
+    public void testErrorGeoFilter(
+            String label,
+            STACFilterModels.StacFilterScenario scenario,
+            STACFilterModels.RequestTarget target,
+            STACFilterModels.FilterLang lang) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        response.assertThat().statusCode(400);
+    }
+
+    static Stream<Arguments> withinFilterErrorCases() {
+        return Stream.of(
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_WITHIN, LINESTRING, 600, 0)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_WITHIN, MULTILINESTRING, 600, 0)),
+                scenarioCases(StacFilterScenario.simple("geo_params.geometry", STACFilterModels.FilterOperator.ST_WITHIN, INVALID_GEOMETRYCOLLECTION, 600, 0))
+        ).flatMap(s -> s);
+    }
+
+
+
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceHeaderFilterIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceHeaderFilterIT.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import io.arlas.server.core.model.enumerations.OperatorEnum;
+import io.arlas.server.core.model.request.Expression;
+import io.arlas.server.core.model.request.Filter;
+import io.arlas.server.core.model.request.MultiValueFilter;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import io.arlas.server.tests.stac.STACFilterModels.StacFilterScenario;
+import io.arlas.server.tests.stac.STACFilterModels.RequestTarget;
+import io.arlas.server.tests.stac.STACFilterModels.FilterLang;
+import io.arlas.server.tests.stac.STACFilterModels.FilterOperator;
+import io.arlas.server.tests.stac.STACFilterModels.FilterClause;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class STACServiceHeaderFilterIT extends AbstractSTACServiceTest {
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("partitionFilterCases")
+    public void testPartitionFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario, target);
+        assertReturnedValues(response, scenario);
+        String path = "features.properties.params.country";
+        response.body(path, everyItem(equalTo("Angola")));
+    }
+
+    static Stream<Arguments> partitionFilterCases() {
+        Filter partitionFilter = new Filter();
+        partitionFilter.f = List.of(new MultiValueFilter<>(new Expression("params.country", OperatorEnum.eq, "Angola")));
+        return Stream.of(
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Actor"),
+                                new FilterClause("params.age", FilterOperator.EQ, 0),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1000000)),
+                        600, 0
+                ).withPartitionFilter(partitionFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Actor"),
+                                new FilterClause("params.age", FilterOperator.GTE, 0),
+                                new FilterClause("params.startdate", FilterOperator.LTE, 1000000)),
+                        600, 0
+                ).withPartitionFilter(partitionFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Chemist"),
+                                new FilterClause("params.age", FilterOperator.EQ, 600),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1050600)),
+                        600, 0
+                ).withPartitionFilter(partitionFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Coder"),
+                                new FilterClause("params.age", FilterOperator.EQ, 1000),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1071000)),
+                        600, 0
+                ).withPartitionFilter(partitionFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Brain Scientist"),
+                                new FilterClause("params.age", FilterOperator.EQ, 400),
+                                new FilterClause("params.startdate", FilterOperator.GTE, 1040000)),
+                        600, 1
+                ).withPartitionFilter(partitionFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.NE, "Actor"),
+                                new FilterClause("params.age", FilterOperator.LT, 7000),
+                                new FilterClause("params.startdate", FilterOperator.GT, 950000)),
+                        600, 36
+                ).withPartitionFilter(partitionFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.GTE, "Chemist"),
+                                new FilterClause("params.age", FilterOperator.LTE, 2600),
+                                new FilterClause("params.startdate", FilterOperator.GTE, 1020000)),
+                        600, 5
+                ).withPartitionFilter(partitionFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.LTE, "Dancer"),
+                                new FilterClause("params.age", FilterOperator.GT, 0),
+                                new FilterClause("params.startdate", FilterOperator.LT, 1100000)),
+                        600, 34
+                ).withPartitionFilter(partitionFilter))
+        ).flatMap(s -> s);
+    }
+
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("authorizeColumnFilterCases")
+    public void testColumnFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario, target);
+        assertReturnedValues(response, scenario);
+        String path = "features.properties.params";
+        JsonPath jsonPath = response.extract().jsonPath();
+        List<Map<String, Object>> params = jsonPath.getList(path);
+        params.forEach(param -> {
+            assertThat(param, hasKey("job"));
+            assertThat(param, hasKey("startdate"));
+            assertThat(param, hasKey("age"));
+            assertThat(param.size(), equalTo(3));
+        });
+
+    }
+
+    static Stream<Arguments> authorizeColumnFilterCases() {
+        String columnFilter = "geodata:params.job,params.age,params.startdate";
+        return Stream.of(
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.LTE, "Dancer"),
+                                new FilterClause("params.age", FilterOperator.GT, 0),
+                                new FilterClause("params.startdate", FilterOperator.LT, 1100000)),
+                        600, 424
+
+                ).withColumnFilter(columnFilter))
+        ).flatMap(s -> s);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("forbiddenCollectionFilterCases")
+    public void testunknowCollectionFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        response.assertThat().statusCode(403);
+    }
+
+    static Stream<Arguments> forbiddenCollectionFilterCases() {
+        String columnFilter = "unknowCollection:params.job,params.age,params.startdate";
+        return Stream.of(
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.LTE, "Dancer"),
+                                new FilterClause("params.age", FilterOperator.GT, 0),
+                                new FilterClause("params.startdate", FilterOperator.LT, 1100000)),
+                        600, 424
+
+                ).withColumnFilter(columnFilter))
+        ).flatMap(s -> s);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("partitionAndColumnFilterCases")
+    public void testPartitionAndColumnFilter(
+            String label,
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario, target);
+        assertReturnedValues(response, scenario);
+        String path = "features.properties.params.country";
+        response.body(path, everyItem(equalTo("Angola")));
+        String pathParams = "features.properties.params";
+        JsonPath jsonPath = response.extract().jsonPath();
+        List<Map<String, Object>> params = jsonPath.getList(pathParams);
+        params.forEach(param -> {
+            assertThat(param, hasKey("job"));
+            assertThat(param, hasKey("startdate"));
+            assertThat(param, hasKey("age"));
+            assertThat(param, hasKey("country"));
+            assertThat(param.size(), equalTo(4));
+        });
+    }
+
+    static Stream<Arguments> partitionAndColumnFilterCases() {
+        Filter partitionFilter = new Filter();
+        partitionFilter.f = List.of(new MultiValueFilter<>(new Expression("params.country", OperatorEnum.eq, "Angola")));
+        String columnFilter = "geodata:params.job,params.age,params.startdate,params.country";
+        return Stream.of(
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Actor"),
+                                new FilterClause("params.age", FilterOperator.EQ, 0),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1000000)),
+                        600, 0
+                ).withPartitionFilter(partitionFilter).withColumnFilter(columnFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Actor"),
+                                new FilterClause("params.age", FilterOperator.GTE, 0),
+                                new FilterClause("params.startdate", FilterOperator.LTE, 1000000)),
+                        600, 0
+                ).withPartitionFilter(partitionFilter).withColumnFilter(columnFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Chemist"),
+                                new FilterClause("params.age", FilterOperator.EQ, 600),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1050600)),
+                        600, 0
+                ).withPartitionFilter(partitionFilter).withColumnFilter(columnFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Coder"),
+                                new FilterClause("params.age", FilterOperator.EQ, 1000),
+                                new FilterClause("params.startdate", FilterOperator.EQ, 1071000)),
+                        600, 0
+                ).withPartitionFilter(partitionFilter).withColumnFilter(columnFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.EQ, "Brain Scientist"),
+                                new FilterClause("params.age", FilterOperator.EQ, 400),
+                                new FilterClause("params.startdate", FilterOperator.GTE, 1040000)),
+                        600, 1
+                ).withPartitionFilter(partitionFilter).withColumnFilter(columnFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.NE, "Actor"),
+                                new FilterClause("params.age", FilterOperator.LT, 7000),
+                                new FilterClause("params.startdate", FilterOperator.GT, 950000)),
+                        600, 36
+                ).withPartitionFilter(partitionFilter).withColumnFilter(columnFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.GTE, "Chemist"),
+                                new FilterClause("params.age", FilterOperator.LTE, 2600),
+                                new FilterClause("params.startdate", FilterOperator.GTE, 1020000)),
+                        600, 5
+                ).withPartitionFilter(partitionFilter).withColumnFilter(columnFilter)),
+                scenarioCases(StacFilterScenario.and(
+                        List.of(
+                                new FilterClause("params.job", FilterOperator.LTE, "Dancer"),
+                                new FilterClause("params.age", FilterOperator.GT, 0),
+                                new FilterClause("params.startdate", FilterOperator.LT, 1100000)),
+                        600, 34
+                ).withPartitionFilter(partitionFilter).withColumnFilter(columnFilter))
+        ).flatMap(s -> s);
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceIT.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import io.arlas.server.stac.model.SearchBody;
+import io.restassured.http.ContentType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import io.arlas.server.tests.stac.STACFilterModels.HttpMethod;
+public class STACServiceIT extends AbstractSTACServiceTest {
+
+
+    @Test
+    public void testConformance() throws Exception {
+        givenFilterableRequestParams().get(getUrlStacPath() + "/conformance")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("conformsTo", contains(arlasConformsTo.toArray(new String[0])));
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("collectionCases")
+    void testSearchAccordingCollectionStatus(String label, List<String> collections, int expectedStatus) throws Exception {
+        Arrays.stream(HttpMethod.values())
+                .forEach(m -> assertSearchAccordingCollectionStatus(m, collections, expectedStatus));
+    }
+
+    private static Stream<Arguments> collectionCases() {
+        return Stream.of(
+                Arguments.of("No collection provided", List.of(), 400),
+                Arguments.of("Multiple collections provided", List.of("collection1", "collection2"), 400),
+                Arguments.of("Exactly one collection provided", List.of("geodata"), 200)
+        );
+    }
+
+    private void assertSearchAccordingCollectionStatus(HttpMethod method, List<String> collections, int expectedStatus) {
+        var request = givenFilterableRequestParams();
+        var path = getUrlStacSearchPath();
+        switch (method) {
+            case GET -> {
+                if (collections != null && !collections.isEmpty()) {
+                    request.param("collections", collections.toArray());
+                }
+                request.get(path)
+                        .then()
+                        .statusCode(expectedStatus);
+            }
+            case POST -> request.body(new SearchBody<>().collections(collections))
+                    .post(path)
+                    .then()
+                    .statusCode(expectedStatus);
+            default -> throw new IllegalArgumentException("Invalid method: " + method);
+        }
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/task/CollectionAutoDiscoverIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/task/CollectionAutoDiscoverIT.java
@@ -22,7 +22,7 @@ package io.arlas.server.tests.task;
 import io.arlas.server.tests.AbstractTestWithDataSet;
 import io.arlas.server.tests.DataSetTool;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.equalTo;

--- a/arlas-tests/src/test/java/io/arlas/server/tests/utils/GeoTypeMapperTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/utils/GeoTypeMapperTest.java
@@ -23,12 +23,13 @@ import io.arlas.commons.exceptions.ArlasException;
 import io.arlas.server.core.impl.elastic.utils.GeoTypeMapper;
 import io.arlas.server.core.model.enumerations.GeoTypeEnum;
 import org.geojson.Point;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class GeoTypeMapperTest {
 

--- a/arlas-tests/src/test/java/io/arlas/server/tests/utils/GeoUtilTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/utils/GeoUtilTest.java
@@ -22,7 +22,7 @@ package io.arlas.server.tests.utils;
 import io.arlas.commons.exceptions.ArlasException;
 import io.arlas.server.core.utils.GeoUtil;
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygon;
@@ -30,9 +30,10 @@ import org.locationtech.jts.geom.Polygon;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class GeoUtilTest {
     @Test

--- a/arlas-tests/src/test/java/io/arlas/server/tests/utils/MapExplorerTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/utils/MapExplorerTest.java
@@ -25,12 +25,13 @@ import io.arlas.server.core.app.ArlasServerConfiguration;
 import io.arlas.server.core.utils.MapExplorer;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.core.IsNot;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MapExplorerTest {
 
@@ -40,13 +41,13 @@ public class MapExplorerTest {
                 MapExplorer.flat(
                         new ObjectMapper().readerFor(new TypeReference<Map<String, Object>>(){}).readValue(this.getClass().getClassLoader().getResourceAsStream("flatMapTest.json")),
                         new MapExplorer.ReduceArrayOnKey(ArlasServerConfiguration.FLATTEN_CHAR), Collections.singleton("a.e.g.2"));
-        Assert.assertThat(flat,IsMapContaining.hasEntry("a_b_0_c", 1));
-        Assert.assertThat(flat,IsMapContaining.hasEntry("a_b_1_c", 2));
-        Assert.assertThat(flat,IsMapContaining.hasEntry("a_b_2_d", "a"));
-        Assert.assertThat(flat,IsMapContaining.hasEntry("a_b_3_d", "b"));
-        Assert.assertThat(flat,IsMapContaining.hasEntry("a_e_f", "a"));
-        Assert.assertThat(flat,IsMapContaining.hasEntry("a_e_g_0", 1));
-        Assert.assertThat(flat,IsMapContaining.hasEntry("a_e_g_1", 2));
-        Assert.assertThat(flat,IsNot.not(IsMapContaining.hasEntry("a_e_g_2", 3)));
+        assertThat(flat,IsMapContaining.hasEntry("a_b_0_c", 1));
+        assertThat(flat,IsMapContaining.hasEntry("a_b_1_c", 2));
+        assertThat(flat,IsMapContaining.hasEntry("a_b_2_d", "a"));
+        assertThat(flat,IsMapContaining.hasEntry("a_b_3_d", "b"));
+        assertThat(flat,IsMapContaining.hasEntry("a_e_f", "a"));
+        assertThat(flat,IsMapContaining.hasEntry("a_e_g_0", 1));
+        assertThat(flat,IsMapContaining.hasEntry("a_e_g_1", 2));
+        assertThat(flat,IsNot.not(IsMapContaining.hasEntry("a_e_g_2", 3)));
     }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/utils/TimestampMapperTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/utils/TimestampMapperTest.java
@@ -23,10 +23,10 @@ import io.arlas.commons.exceptions.ArlasException;
 import io.arlas.server.core.utils.TimestampTypeMapper;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TimestampMapperTest {
 

--- a/conf/configuration.yaml
+++ b/conf/configuration.yaml
@@ -156,12 +156,17 @@ arlas_stac:
     - https://api.stacspec.org/v1.0.0/item-search
     - https://api.stacspec.org/v1.0.0/ogcapi-features
     - https://api.stacspec.org/v1.0.0/collections
-    - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
-#   - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
     - https://api.stacspec.org/v1.0.0/item-search#sort
     - https://api.stacspec.org/v1.0.0/item-search#context
-#   - https://api.stacspec.org/v1.0.0/item-search#fields
-#   - https://api.stacspec.org/v1.0.0/item-search#filter
+    - https://api.stacspec.org/v1.0.0/item-search#filter
+    - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
+    - http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter
+    - http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter
+    - http://www.opengis.net/spec/cql2/1.0/conf/cql2-text
+    - http://www.opengis.net/spec/cql2/1.0/conf/cql2-json
+    - http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2
+    - http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions
+    - http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions-plus
 
 
 arlas_cors:

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!-- DEV TOOLS -->
         <cyclops.version>10.4.1</cyclops.version>
         <!-- TESTS -->
-        <junit.version>4.13.2</junit.version>
+        <junit.version>6.1.0</junit.version>
         <org.hamcrest.version>2.2</org.hamcrest.version>
         <io.rest-assured.version>5.4.0</io.rest-assured.version>
         <!-- REST AND DROPWIZARD-->
@@ -82,8 +82,8 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
@@ -161,6 +161,11 @@
         </plugins>
     </build>
     <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
         <repository>
             <id>osgeo</id>
             <name>OSGeo Release Repository</name>

--- a/scripts/ci/tests-integration-stage.sh
+++ b/scripts/ci/tests-integration-stage.sh
@@ -97,7 +97,7 @@ function test_rest() {
         -e WKT_GEOMETRIES=${WKT_GEOMETRIES} \
         --net arlas_default \
         maven:3.8.5-openjdk-17 \
-        mvn "-Dit.test=*,!AuthServiceIT,!CollectionTool,!CSWServiceIT,!WFSService*IT" verify -DskipTests=false -DfailIfNoTests=false -B
+        mvn "-Dit.test=*,!AuthServiceIT,!CollectionTool,!CSWServiceIT,!WFSService*IT,!STACService*IT" verify -DskipTests=false -DfailIfNoTests=false -B
 }
 
 function test_auth() {
@@ -188,6 +188,61 @@ function test_wfs() {
         mvn exec:java -Dexec.mainClass="io.arlas.server.tests.CollectionTool" -Dexec.classpathScope=test -Dexec.args="delete" -pl arlas-tests -B
 }
 
+
+
+function test_stac_filter() {
+    export ARLAS_PREFIX="/arlastest"
+    export ARLAS_APP_PATH="/pathtest"
+    export ARLAS_BASE_URI="http://arlas-server:9999/pathtest/arlastest/"
+    export ARLAS_SERVICE_STAC_ENABLE=true
+    export ARLAS_INSPIRE_ENABLED=true
+    start_stack
+    docker run --rm \
+        -w /opt/maven \
+        -v $PWD:/opt/maven \
+        -v $HOME/.m2:/root/.m2 \
+        -e ARLAS_HOST="arlas-server" \
+        -e ARLAS_PORT="9999" \
+        -e ARLAS_PREFIX=${ARLAS_PREFIX} \
+        -e ARLAS_APP_PATH=${ARLAS_APP_PATH} \
+        -e ARLAS_INSPIRE_ENABLED=${ARLAS_INSPIRE_ENABLED} \
+        -e ARLAS_ELASTIC_NODES="elasticsearch:9200" \
+        -e ALIASED_COLLECTION=${ALIASED_COLLECTION} \
+        --net arlas_default \
+        maven:3.8.5-openjdk-17 \
+        mvn exec:java -Dexec.mainClass="io.arlas.server.tests.CollectionTool" -Dexec.classpathScope=test -Dexec.args="$1" -pl arlas-tests -B
+
+    docker run --rm \
+        -w /opt/maven \
+        -v $PWD:/opt/maven \
+        -v $HOME/.m2:/root/.m2 \
+        -e ARLAS_HOST="arlas-server" \
+        -e ARLAS_PORT="9999" \
+        -e ARLAS_PREFIX=${ARLAS_PREFIX} \
+        -e ARLAS_APP_PATH=${ARLAS_APP_PATH} \
+        -e ARLAS_INSPIRE_ENABLED=${ARLAS_INSPIRE_ENABLED}\
+        -e ARLAS_ELASTIC_NODES="elasticsearch:9200" \
+        -e ALIASED_COLLECTION=${ALIASED_COLLECTION} \
+        --net arlas_default \
+        maven:3.8.5-openjdk-17 \
+        mvn "-Dit.test=STACService*IT" verify -DskipTests=false -DfailIfNoTests=false -B
+
+    docker run --rm \
+        -w /opt/maven \
+        -v $PWD:/opt/maven \
+        -v $HOME/.m2:/root/.m2 \
+        -e ARLAS_HOST="arlas-server" \
+        -e ARLAS_PORT="9999" \
+        -e ARLAS_PREFIX=${ARLAS_PREFIX} \
+        -e ARLAS_APP_PATH=${ARLAS_APP_PATH} \
+        -e ARLAS_ELASTIC_NODES="elasticsearch:9200" \
+        -e ALIASED_COLLECTION=${ALIASED_COLLECTION} \
+        --net arlas_default \
+        maven:3.8.5-openjdk-17 \
+        mvn exec:java -Dexec.mainClass="io.arlas.server.tests.CollectionTool" -Dexec.classpathScope=test -Dexec.args="$2" -pl arlas-tests -B
+}
+
+
 function test_stac() {
     export ARLAS_PREFIX="/arlastest"
     export ARLAS_APP_PATH="/pathtest"
@@ -214,7 +269,7 @@ function test_stac() {
          --net arlas_default \
          --env STAC_URL="${ARLAS_BASE_URI}stac" \
          --env STAC_COLLECTION="geodata" \
-         gisaia/stac-api-validator:0.6.5
+         gisaia/stac-api-validator:0.7.2
 
     docker run --rm \
          --net arlas_default \
@@ -305,6 +360,7 @@ if [ "$STAGE" == "REST" ]; then export ALIASED_COLLECTION="false"; export WKT_GE
 if [ "$STAGE" == "WFS" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_wfs; fi
 if [ "$STAGE" == "CSW" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_csw; fi
 if [ "$STAGE" == "STAC" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_stac "loadstac" "delete"; fi
+if [ "$STAGE" == "STAC_FILTER" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_stac_filter "loadstac" "delete";  fi
 if [ "$STAGE" == "REST_WKT_GEOMETRIES" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="true"; test_rest; fi
 if [ "$STAGE" == "REST_ALIASED" ]; then export ALIASED_COLLECTION="true"; export WKT_GEOMETRIES="false"; test_rest; fi
 if [ "$STAGE" == "WFS_ALIASED" ]; then export ALIASED_COLLECTION="true"; export WKT_GEOMETRIES="false"; test_wfs; fi

--- a/scripts/ci/tests-integration.sh
+++ b/scripts/ci/tests-integration.sh
@@ -40,6 +40,7 @@ cd ${SCRIPT_PATH}/../..
 ./scripts/ci/tests-integration-stage.sh --stage=REST
 ./scripts/ci/tests-integration-stage.sh --stage=REST_WKT_GEOMETRIES
 ./scripts/ci/tests-integration-stage.sh --stage=STAC
+./scripts/ci/tests-integration-stage.sh --stage=STAC_FILTER
 ./scripts/ci/tests-integration-stage.sh --stage=WFS
 ./scripts/ci/tests-integration-stage.sh --stage=CSW
 ./scripts/ci/tests-integration-stage.sh --stage=DOC

--- a/stac-api/pom.xml
+++ b/stac-api/pom.xml
@@ -27,6 +27,18 @@
             <artifactId>itu</artifactId>
             <version>${itu.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-cql2-text</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-cql2-json</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/stac-api/src/main/java/io/arlas/server/stac/api/ArlasFilterUtils.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/ArlasFilterUtils.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.stac.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.geotools.api.filter.*;
+import org.geotools.api.filter.expression.Expression;
+import org.geotools.api.filter.expression.Literal;
+import org.geotools.api.filter.expression.PropertyName;
+import org.geotools.api.filter.spatial.BinarySpatialOperator;
+import org.geotools.api.filter.spatial.Intersects;
+import org.geotools.api.filter.spatial.Within;
+import org.geotools.filter.IsNotEqualToImpl;
+import org.geotools.filter.LikeFilterImpl;
+import org.locationtech.jts.geom.Geometry;
+
+import io.arlas.commons.exceptions.ArlasException;
+import io.arlas.commons.exceptions.InvalidParameterException;
+import io.arlas.commons.utils.StringUtil;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.GeometryCollection;
+
+public class ArlasFilterUtils {
+
+    public static List<String> cql2toArlasFilterList(Filter filter, Boolean isStacModel) throws ArlasException {
+        List<String> filters = new ArrayList<>();
+        if (filter == null) {
+            return filters;
+        }
+        // AND: flatten children
+        if (filter instanceof And) {
+            And and = (And) filter;
+            for (Filter child : and.getChildren()) {
+                filters.addAll(cql2toArlasFilterList(child, isStacModel));
+            }
+            return filters;
+        }
+
+        // OR / NOT are not supported in this conversion (would require translation to ARLAS syntax supporting boolean logic)
+        if (filter instanceof Or) {
+            throw new InvalidParameterException("CQL2 OR filters are not supported by ARLAS STAC filter");
+        }
+        if (filter instanceof Not not) {
+            Filter child = not.getFilter();
+            // Support ONLY the GeoTools form generated from "<>":
+            // NOT (property = literal)
+            if (child instanceof BinaryComparisonOperator cmp && child instanceof PropertyIsEqualTo) {
+                filters.add(toBinaryComparisonFilter(cmp, "ne", isStacModel));
+                return filters;
+            }
+
+            throw new InvalidParameterException("CQL2 NOT filters are not supported by ARLAS STAC filter");
+        }
+
+        // Comparison operators
+        if (filter instanceof BinaryComparisonOperator cmp) {
+            if (filter instanceof PropertyIsEqualTo) {
+                filters.add(toBinaryComparisonFilter(cmp, "eq", isStacModel));
+                return filters;
+            } else if (filter instanceof PropertyIsGreaterThanOrEqualTo) {
+                filters.add(toBinaryComparisonFilter(cmp, "gte", isStacModel));
+                return filters;
+            } else if (filter instanceof PropertyIsLessThanOrEqualTo) {
+                filters.add(toBinaryComparisonFilter(cmp, "lte", isStacModel));
+                return filters;
+            } else if (filter instanceof PropertyIsGreaterThan) {
+                filters.add(toBinaryComparisonFilter(cmp, "gt", isStacModel));
+                return filters;
+            } else if (filter instanceof PropertyIsLessThan) {
+                filters.add(toBinaryComparisonFilter(cmp, "lt", isStacModel));
+                return filters;
+            } else if (filter instanceof IsNotEqualToImpl) {
+                filters.add(toBinaryComparisonFilter(cmp, "ne", isStacModel));
+                return filters;
+            }
+        }
+
+        if (filter instanceof LikeFilterImpl likeFilter) {
+            filters.add(toLikeComparisonFilter(likeFilter, isStacModel));
+            return filters;
+        }
+
+        // BETWEEN -> ARLAS range
+        if (filter instanceof PropertyIsBetween between) {
+            Expression expr = between.getExpression();
+            Expression lower = between.getLowerBoundary();
+            Expression upper = between.getUpperBoundary();
+
+            if (!(expr instanceof PropertyName)) {
+                throw new InvalidParameterException("Unsupported BETWEEN filter: left-hand expression is not a property");
+            }
+            String property = normalizeProperty(((PropertyName) expr).getPropertyName(), isStacModel);
+            String low = literalToString(lower);
+            String high = literalToString(upper);
+            filters.add(StringUtil.concat(property, ":", "range", ":[", low, "<", high, "]"));
+            return filters;
+        }
+
+        // Spatial operators: INTERSECTS, WITHIN
+        if (filter instanceof Intersects || filter instanceof Within) {
+            String opName = filter instanceof Within ? "within" : "intersects";
+            Expression e1 = ((BinarySpatialOperator) filter).getExpression1();;
+            Expression e2 =  ((BinarySpatialOperator) filter).getExpression2();
+            if (e1 == null || e2 == null) {
+                // fallback: use filter.toString() as last resort
+                filters.add(opName + ":" + filter.toString());
+                return filters;
+            }
+            String property;
+            Expression geometryExpr;
+            if (e1 instanceof PropertyName p) {
+                property = normalizeProperty(p.getPropertyName(), isStacModel);
+                geometryExpr = e2;
+            } else if (e2 instanceof PropertyName p) {
+                property = normalizeProperty(p.getPropertyName(), isStacModel);
+                geometryExpr = e1;
+            } else {
+                throw new InvalidParameterException("Unsupported spatial filter: no property name found in filter " + filter);
+            }
+            if (filter instanceof Within) {
+                validateWithinGeometry(geometryExpr);
+            }
+            String geomText = literalToGeometryText(geometryExpr);
+            filters.add(StringUtil.concat(property, ":", opName, ":", geomText));
+            return filters;
+        }
+
+        // If none matched, try to provide a helpful message
+        throw new InvalidParameterException("Unsupported CQL2 filter type: " + filter.getClass().getSimpleName() + " (" + filter + ")");
+    }
+
+
+    private static String literalToString(Expression expr) {
+        if (expr instanceof Literal literal) {
+            Object val = literal.getValue();
+            return val == null ? "null" : val.toString();
+        } else {
+            // fallback to expression string form
+            return expr == null ? "null" : expr.toString();
+        }
+    }
+
+    private static String literalToGeometryText(Expression expr) {
+        if (expr instanceof Literal literal) {
+            Object val = literal.getValue();
+            if (val instanceof Geometry geometry) {
+                return geometry.toText();
+            } else {
+                return val == null ? "null" : val.toString();
+            }
+        } else {
+            return expr == null ? "null" : expr.toString();
+        }
+    }
+
+    private static String toLikeComparisonFilter(
+            LikeFilterImpl cmp,
+            Boolean isStacModel
+    ) throws InvalidParameterException {
+        Expression e1 = cmp.getExpression();
+        String e2 = cmp.getLiteral();
+        // Validate LIKE literal: reject unescaped leading wildcard, allow escaped leading wildcard
+        validateLikeLiteral(cmp);
+        String property;
+        String value;
+        if (e1 instanceof PropertyName p) {
+            property = normalizeProperty(p.getPropertyName(), isStacModel);
+            value = e2;
+        } else {
+            throw new InvalidParameterException(
+                    "Unsupported comparison: no property name found in filter " + cmp
+            );
+        }
+        return StringUtil.concat(property, ":", "like", ":", value);
+    }
+
+    private static String toBinaryComparisonFilter(
+            BinaryComparisonOperator cmp,
+            String arlasOperator,
+            Boolean isStacModel
+    ) throws InvalidParameterException {
+        Expression e1 = cmp.getExpression1();
+        Expression e2 = cmp.getExpression2();
+
+        String property;
+        String value;
+
+        if (e1 instanceof PropertyName p) {
+            property = normalizeProperty(p.getPropertyName(), isStacModel);
+            value = literalToString(e2);
+        } else if (e2 instanceof PropertyName p) {
+            property = normalizeProperty(p.getPropertyName(), isStacModel);
+            value = literalToString(e1);
+        } else {
+            throw new InvalidParameterException(
+                    "Unsupported comparison: no property name found in filter " + cmp
+            );
+        }
+
+        return StringUtil.concat(property, ":", arlasOperator, ":", value);
+    }
+
+    private static String normalizeProperty(String property, Boolean isStacModel) {
+        String normalized = property.replace('/', '.');
+        if (Boolean.TRUE.equals(isStacModel)) {
+            normalized = normalized.replaceFirst(":", "__");
+        }
+        return normalized;
+    }
+
+    /**
+     * Validates LIKE literal to reject unescaped leading wildcards.
+     * - Exception if pattern starts with an unescaped wildcard (default '%').
+     * - Allowed if the leading wildcard is escaped with the escape character.
+     */
+    private static void validateLikeLiteral(PropertyIsLike like) throws InvalidParameterException {
+        String literal = like.getLiteral();
+        if (literal == null || literal.isEmpty()) {
+            return;
+        }
+        String wildCard = "%";
+        String escape = like.getEscape();
+        if (escape != null && !escape.isEmpty() && literal.startsWith(escape + wildCard)) {
+            return;
+        }
+        if (literal.startsWith(wildCard)) {
+            throw new InvalidParameterException("LIKE filters starting with an unescaped wildcard are not supported");
+        }
+    }
+
+    /**
+     * Validates geometry for CQL2 WITHIN filters.
+     * Rejects:
+     * - LineString
+     * - MultiLineString
+     * - GeometryCollection containing at least one LineString or MultiLineString
+     */
+    private static void validateWithinGeometry(Expression expr) throws InvalidParameterException {
+        if (!(expr instanceof Literal literal)) {
+            return;
+        }
+        Object val = literal.getValue();
+        if (!(val instanceof Geometry geometry)) {
+            return;
+        }
+        if (geometry instanceof LineString) {
+            throw new InvalidParameterException("Unsupported spatial filter: within with LineString geometries");
+        }
+        if (geometry instanceof MultiLineString) {
+            throw new InvalidParameterException("Unsupported spatial filter: within with MultiLineString geometries");
+        }
+        if (containsLine(geometry)) {
+            throw new InvalidParameterException("Unsupported spatial filter: within with GeometryCollection containing LineString or MultiLineString");
+        }
+    }
+
+    private static boolean containsLine(Geometry geometry) {
+        if (geometry instanceof LineString) {
+            return true;
+        }
+
+        if (geometry instanceof MultiLineString) {
+            return true;
+        }
+
+        if (geometry instanceof GeometryCollection collection) {
+            for (int i = 0; i < collection.getNumGeometries(); i++) {
+                if (containsLine(collection.getGeometryN(i))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/stac-api/src/main/java/io/arlas/server/stac/api/CQL2FilterUtils.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/CQL2FilterUtils.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.stac.api;
+
+import io.arlas.commons.exceptions.ArlasException;
+import io.arlas.commons.exceptions.InvalidParameterException;
+import io.arlas.server.stac.model.SearchBody;
+import org.geotools.api.filter.And;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.Not;
+import org.geotools.api.filter.Or;
+import org.geotools.api.filter.expression.Expression;
+import org.geotools.api.filter.expression.Literal;
+import org.geotools.api.filter.spatial.Beyond;
+import org.geotools.api.filter.spatial.BinarySpatialOperator;
+import org.geotools.api.filter.spatial.Contains;
+import org.geotools.api.filter.spatial.Crosses;
+import org.geotools.api.filter.spatial.Disjoint;
+import org.geotools.api.filter.spatial.DWithin;
+import org.geotools.api.filter.spatial.Equals;
+import org.geotools.api.filter.spatial.Intersects;
+import org.geotools.api.filter.spatial.Overlaps;
+import org.geotools.api.filter.spatial.Touches;
+import org.geotools.api.filter.spatial.Within;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geootols.filter.text.cql_2.CQL2;
+import org.geotools.filter.text.cqljson.CQL2Json;
+import org.locationtech.jts.algorithm.Orientation;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Utility methods for parsing CQL2 filters and applying a targeted post-processing step
+ * for BBOX-derived polygons.
+ *
+ * <p>This class keeps GeoTools {@link CQL2#toFilter(String)} as the single parser so
+ * complex filters such as nested AND/OR/NOT expressions are still fully supported.
+ *
+ * <p>The post-processing is intentionally restricted:
+ * <ul>
+ *   <li>It only runs if the original CQL2 text contains a {@code BBOX(...)} constructor.</li>
+ *   <li>It only rewrites literal geometries that are simple axis-aligned rectangles.</li>
+ *   <li>It only changes clockwise polygons into counter-clockwise polygons.</li>
+ * </ul>
+ *
+ * <p>This avoids modifying user-provided geometries such as explicit
+ * {@code POLYGON(...)} literals.
+ */
+public final class CQL2FilterUtils {
+
+    private static final FilterFactory FF = CommonFactoryFinder.getFilterFactory();
+    private static final Pattern BBOX_PATTERN = Pattern.compile("\\bBBOX\\s*\\(", Pattern.CASE_INSENSITIVE);
+
+    private CQL2FilterUtils() {
+    }
+
+    /**
+     * Parse the provided CQL2 string with GeoTools and, if the original text contains
+     * a {@code BBOX(...)} constructor, normalize BBOX-derived polygon literals to
+     * counter-clockwise orientation.
+     *
+     * @param cql2 the original CQL2 string
+     * @param lang the original lang cql-json or cql-text
+     * @return the parsed filter, optionally rewritten for BBOX polygon orientation
+     * @throws Exception if the CQL2 parser fails
+     */
+    public static Filter toFilterWithBboxCcwCorrection(String cql2, String lang) throws ArlasException {
+        Filter cql2_filter = null;
+        if(lang.equals(SearchBody.CQL2_TEXT_STRING)){
+            try {
+                cql2_filter = CQL2.toFilter(cql2);
+            } catch (Exception e) {
+                throw new InvalidParameterException("Invalid CQL2-JSON filter: " + e.getMessage());
+            }
+        }else if(lang.equals(SearchBody.CQL2_JSON_STRING)){
+            try {
+                cql2_filter = CQL2Json.toFilter(cql2);
+            } catch (Exception e) {
+                throw new InvalidParameterException("Invalid CQL2-JSON filter: " + e.getMessage());
+            }
+        }else{
+            throw new InvalidParameterException("Unsupported filter-lang: " + lang);
+        }
+        if (!containsBboxConstructor(cql2)) {
+            return cql2_filter;
+        }
+        return rewriteFilter(cql2_filter);
+    }
+
+    /**
+     * Detect whether the original CQL2 text contains a {@code BBOX(...)} constructor.
+     *
+     * <p>This is used as the primary safety gate before any geometry rewriting happens.
+     *
+     * @param cql2 the original CQL2 string
+     * @return true if the text contains a BBOX constructor
+     */
+    static boolean containsBboxConstructor(String cql2) {
+        return cql2 != null && BBOX_PATTERN.matcher(cql2).find();
+    }
+
+    /**
+     * Recursively rewrite the filter tree.
+     *
+     * @param filter the input filter
+     * @return the rewritten filter
+     */
+    private static Filter rewriteFilter(Filter filter) {
+        if (filter == null) {
+            return null;
+        }
+
+        if (filter instanceof And andFilter) {
+            List<Filter> children = new ArrayList<>();
+            for (Filter child : andFilter.getChildren()) {
+                children.add(rewriteFilter(child));
+            }
+            return FF.and(children);
+        }
+
+        if (filter instanceof Or orFilter) {
+            List<Filter> children = new ArrayList<>();
+            for (Filter child : orFilter.getChildren()) {
+                children.add(rewriteFilter(child));
+            }
+            return FF.or(children);
+        }
+
+        if (filter instanceof Not notFilter) {
+            return FF.not(rewriteFilter(notFilter.getFilter()));
+        }
+
+        if (filter instanceof BinarySpatialOperator spatial) {
+            return rewriteSpatialFilter(spatial);
+        }
+
+        return filter;
+    }
+
+    /**
+     * Rewrite a spatial filter if one side contains a literal rectangle polygon
+     * that looks like it was produced from a BBOX constructor.
+     *
+     * @param spatial the spatial filter to inspect
+     * @return the same filter or a rewritten one
+     */
+    private static Filter rewriteSpatialFilter(BinarySpatialOperator spatial) {
+        Expression left = spatial.getExpression1();
+        Expression right = spatial.getExpression2();
+
+        Expression newLeft = rewriteExpressionIfNeeded(left);
+        Expression newRight = rewriteExpressionIfNeeded(right);
+
+        if (newLeft == left && newRight == right) {
+            return spatial;
+        }
+
+        return rebuildSpatialFilter(spatial, newLeft, newRight);
+    }
+
+    /**
+     * Rewrite an expression only if it is a literal polygon matching the BBOX rectangle pattern
+     * and currently oriented clockwise.
+     *
+     * @param expression the expression to inspect
+     * @return the original expression or a corrected literal
+     */
+    private static Expression rewriteExpressionIfNeeded(Expression expression) {
+        if (!(expression instanceof Literal literal)) {
+            return expression;
+        }
+
+        Object value = literal.getValue();
+        if (!(value instanceof Polygon polygon)) {
+            return expression;
+        }
+
+        if (!isAxisAlignedRectangle(polygon)) {
+            return expression;
+        }
+
+        if (isCounterClockwise(polygon)) {
+            return expression;
+        }
+
+        Polygon corrected = forceCounterClockwise(polygon);
+        return FF.literal(corrected);
+    }
+
+    /**
+     * Rebuild a spatial filter with the same operator type and updated expressions.
+     *
+     * @param original the original spatial filter
+     * @param left the left expression
+     * @param right the right expression
+     * @return a rebuilt filter of the same type
+     */
+    private static Filter rebuildSpatialFilter(BinarySpatialOperator original, Expression left, Expression right) {
+        if (original instanceof Intersects) {
+            return FF.intersects(left, right);
+        }
+        if (original instanceof Within) {
+            return FF.within(left, right);
+        }
+        if (original instanceof Contains) {
+            return FF.contains(left, right);
+        }
+        if (original instanceof Overlaps) {
+            return FF.overlaps(left, right);
+        }
+        if (original instanceof Crosses) {
+            return FF.crosses(left, right);
+        }
+        if (original instanceof Touches) {
+            return FF.touches(left, right);
+        }
+        if (original instanceof Disjoint) {
+            return FF.disjoint(left, right);
+        }
+        if (original instanceof Equals) {
+            return FF.equal(left, right);
+        }
+        if (original instanceof DWithin dWithin) {
+            return FF.dwithin(left, right, dWithin.getDistance(), dWithin.getDistanceUnits());
+        }
+        if (original instanceof Beyond beyond) {
+            return FF.beyond(left, right, beyond.getDistance(), beyond.getDistanceUnits());
+        }
+
+        return original;
+    }
+
+    /**
+     * Detect whether a polygon is a simple axis-aligned rectangle.
+     *
+     * <p>This is a secondary safety check used to identify the typical geometry
+     * generated from a BBOX constructor.
+     *
+     * @param polygon the polygon to inspect
+     * @return true if the polygon is a closed 4-corner axis-aligned rectangle
+     */
+    static boolean isAxisAlignedRectangle(Polygon polygon) {
+        if (polygon == null || polygon.isEmpty() || polygon.getNumInteriorRing() > 0) {
+            return false;
+        }
+
+        Coordinate[] coordinates = polygon.getExteriorRing().getCoordinates();
+        if (coordinates.length != 5) {
+            return false;
+        }
+
+        Coordinate p0 = coordinates[0];
+        Coordinate p1 = coordinates[1];
+        Coordinate p2 = coordinates[2];
+        Coordinate p3 = coordinates[3];
+        Coordinate p4 = coordinates[4];
+
+        if (!sameCoordinate(p0, p4)) {
+            return false;
+        }
+
+        double minX = min(p0.x, p1.x, p2.x, p3.x);
+        double maxX = max(p0.x, p1.x, p2.x, p3.x);
+        double minY = min(p0.y, p1.y, p2.y, p3.y);
+        double maxY = max(p0.y, p1.y, p2.y, p3.y);
+
+        boolean[] matched = new boolean[4];
+        for (int i = 0; i < 4; i++) {
+            Coordinate c = coordinates[i];
+            if (sameCoordinate(c, new Coordinate(minX, minY))) matched[0] = true;
+            else if (sameCoordinate(c, new Coordinate(maxX, minY))) matched[1] = true;
+            else if (sameCoordinate(c, new Coordinate(maxX, maxY))) matched[2] = true;
+            else if (sameCoordinate(c, new Coordinate(minX, maxY))) matched[3] = true;
+            else return false;
+        }
+
+        return matched[0] && matched[1] && matched[2] && matched[3];
+    }
+
+    /**
+     * Return true if the polygon exterior ring is counter-clockwise.
+     *
+     * <p>This implementation delegates orientation detection to JTS.
+     *
+     * @param polygon the polygon to inspect
+     * @return true if the exterior ring is counter-clockwise
+     */
+    static boolean isCounterClockwise(Polygon polygon) {
+        Coordinate[] coordinates = polygon.getExteriorRing().getCoordinates();
+        return Orientation.isCCW(coordinates);
+    }
+
+    /**
+     * Return a copy of the polygon whose exterior ring is counter-clockwise.
+     *
+     * <p>Interior rings are preserved as-is because the target use case is a simple
+     * BBOX-derived rectangle with no holes.
+     *
+     * @param polygon the polygon to normalize
+     * @return a polygon with counter-clockwise exterior ring
+     */
+    static Polygon forceCounterClockwise(Polygon polygon) {
+        LinearRing shell = (LinearRing) polygon.getExteriorRing();
+        Coordinate[] shellCoordinates = shell.getCoordinates();
+
+        Coordinate[] reversed = new Coordinate[shellCoordinates.length];
+        for (int i = 0; i < shellCoordinates.length; i++) {
+            reversed[i] = shellCoordinates[shellCoordinates.length - 1 - i];
+        }
+
+        LinearRing correctedShell = polygon.getFactory().createLinearRing(reversed);
+        return polygon.getFactory().createPolygon(correctedShell, null);
+    }
+
+    private static boolean sameCoordinate(Coordinate a, Coordinate b) {
+        return nearlyEqual(a.x, b.x) && nearlyEqual(a.y, b.y);
+    }
+
+    private static boolean nearlyEqual(double a, double b) {
+        return Math.abs(a - b) < 1e-12;
+    }
+
+    private static double min(double... values) {
+        double result = values[0];
+        for (double value : values) {
+            result = Math.min(result, value);
+        }
+        return result;
+    }
+
+    private static double max(double... values) {
+        double result = values[0];
+        for (double value : values) {
+            result = Math.max(result, value);
+        }
+        return result;
+    }
+}

--- a/stac-api/src/main/java/io/arlas/server/stac/api/StacCollectionsRESTService.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/StacCollectionsRESTService.java
@@ -224,6 +224,19 @@ public class StacCollectionsRESTService extends StacRESTService {
                                         If a feature has multiple temporal properties, it is the decision of the server whether only a single temporal property is used to determine the extent or all relevant temporal properties.""",
                                         style = ParameterStyle.FORM)
                                 @QueryParam(value = "datetime") String datetime,
+                                @Parameter(name = "filter", required = false, description = "**Extension:** Filter  A CQL filter expression for filtering items.")
+                                    @QueryParam(value = "filter") String filter,
+
+                                @Parameter(name = "filter-lang", required = false,
+                                        description = """
+                                        **Extension:** Filter  The language in which the filter expression is written.
+                                        If not provided, defaults to 'cql2-text'.
+                                        Allowed values: 'cql2-text', 'cql2-json'
+                                        Example: 'cql2-text', 'cql2-json'""",
+                                        style = ParameterStyle.FORM,
+                                        schema = @Schema(type = "string", allowableValues = {"cql2-text", "cql2-json"}, defaultValue = "cql2-text")
+                                )
+                                    @QueryParam(value = "filter-lang") String filterLang,
 
                                 // --------------------------------------------------------
                                 // -----------------------  PAGE   -----------------------
@@ -268,7 +281,9 @@ public class StacCollectionsRESTService extends StacRESTService {
                 .from(from.get())
                 .sortBy(sortBy)
                 .after(after)
-                .before(before);
+                .before(before)
+                .filter(filter)
+                .filterLang(filterLang);
 
         return cache(Response.ok(getStacFeatureCollection(collectionReference, partitionFilter, Optional.ofNullable(columnFilter),
                 searchBody, f, uriInfo, "GET", true)), 0);

--- a/stac-api/src/main/java/io/arlas/server/stac/api/StacRESTService.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/StacRESTService.java
@@ -21,7 +21,6 @@ package io.arlas.server.stac.api;
 
 import com.ethlo.time.ITU;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import io.arlas.commons.exceptions.ArlasException;
@@ -46,7 +45,6 @@ import io.arlas.server.stac.model.*;
 import io.dropwizard.jersey.params.IntParam;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -56,6 +54,7 @@ import org.geojson.Feature;
 import org.geojson.FeatureCollection;
 import org.geojson.GeoJsonObject;
 import org.geojson.Polygon;
+import org.geotools.api.filter.Filter;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.geojson.GeoJsonReader;
@@ -70,6 +69,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.arlas.server.core.utils.TimestampTypeMapper.formatDate;
+import static io.arlas.server.stac.api.CQL2FilterUtils.toFilterWithBboxCcwCorrection;
 import static jakarta.ws.rs.core.UriBuilder.fromUri;
 
 @Path("/stac")
@@ -271,6 +271,12 @@ public abstract class StacRESTService {
                                                                  String method,
                                                                  boolean isOgc) throws ArlasException {
         Search search = new Search();
+        List<String> arlasFilterString = new ArrayList<>();
+        if (Objects.nonNull(body) && Objects.nonNull(body.getFilterLang())) {
+            Filter cql2Filter = toFilterWithBboxCcwCorrection(body.getFilter(),body.getFilterLang());
+            arlasFilterString.addAll(ArlasFilterUtils.cql2toArlasFilterList(cql2Filter, collectionReference.params.isStacModel));
+        }
+        filter.addAll(arlasFilterString);
         search.filter = ParamsParser.getFilter(collectionReference, filter, null, null, true);
         if (body != null) {
             String sortBy = null;
@@ -299,7 +305,7 @@ public abstract class StacRESTService {
         HashMap<String, Object> context = new HashMap<>();
 
 
-        List<StacLink> links = new ArrayList<>(); // TODO what do we put in there?
+        List<StacLink> links = new ArrayList<>();
         links.add(getRootLink(uriInfo));
         links.add(getParentLink(uriInfo));
 
@@ -324,7 +330,6 @@ public abstract class StacRESTService {
             Arrays.asList("self", "next", "previous").forEach(rel -> {
                 if (context.containsKey(rel)) {
                     if (method.equals("POST")) {
-                        // TODO : fix when body is null!!
                         links.add(getRawLink(((Link)context.get(rel)).href, rel, getSearchBody(body, (Search) ((Link)context.get(rel)).body)));
                     } else {
                         links.add(getRawLink(((Link)context.get(rel)).href, rel));
@@ -413,7 +418,7 @@ public abstract class StacRESTService {
     protected String getGeoFilter(GeoJsonObject geojson, CollectionReference collectionReference) throws ArlasException {
         if (geojson != null) {
             try {
-                // righthand parameter is forced for STAC; therefore, passed righthand WKTs will be used correctly;
+                // STAC forces the right-hand parameter, so passed WKTs are used correctly
                 Geometry geometry = reader.read(writer.writeValueAsString(geojson));
                 return StringUtil.concat(collectionReference.params.geometryPath, ":", OperatorEnum.intersects.name(), ":",
                         geometry.toText());
@@ -428,7 +433,7 @@ public abstract class StacRESTService {
         List<Double> bboxList = null;
         try {
             if (bbox != null) {
-                bboxList = Stream.of(bbox.split(",")).map(Double::valueOf).collect(Collectors.toList());
+                bboxList = Stream.of(bbox.split(",")).map(Double::valueOf).toList();
             }
         } catch (NumberFormatException e) {
             throw new InvalidParameterException("Invalid bbox definition: " + bbox);

--- a/stac-api/src/main/java/io/arlas/server/stac/api/StacSearchRESTService.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/StacSearchRESTService.java
@@ -42,9 +42,11 @@ import io.swagger.v3.oas.annotations.enums.ParameterStyle;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
@@ -146,12 +148,24 @@ public class StacSearchRESTService extends StacRESTService {
 //            @Parameter(name = "fields", description = "**Optional Extension:** Fields  Determines the shape of the features in the response")
 //            @QueryParam(value = "fields") String fields,
 
-//            @Parameter(name = "filter", required = true, description = "**Extension:** Filter  A CQL filter expression for filtering items.")
-//            @QueryParam(value = "filter") Filter filter,
+        @Parameter(name = "filter", required = false, description = "**Extension:** Filter  A CQL filter expression for filtering items.")
+        @QueryParam(value = "filter") String filter,
 
-            @Parameter(name = "sortby", description = """
-                    **Optional Extension:** Sort  An array of property names, prefixed by either "+" for ascending or "-" for descending. If no prefix is provided, "+" is assumed.""")
-            @QueryParam(value = "sortby") String sortBy,
+        @Parameter(name = "filter-lang", required = false,
+                        description = """
+                                        **Extension:** Filter  The language in which the filter expression is written.
+                                        If not provided, defaults to 'cql2-text'.
+                                        Allowed values: 'cql2-text', 'cql2-json'
+                                        Example: 'cql2-text', 'cql2-json'
+                        """,
+                        style = ParameterStyle.FORM,
+                        schema = @Schema(type = "string", allowableValues = {"cql2-text", "cql2-json"}, defaultValue = "cql2-text")
+        )
+        @QueryParam(value = "filter-lang") String filterLang,
+
+        @Parameter(name = "sortby", description = """
+                        **Optional Extension:** Sort  An array of property names, prefixed by either "+" for ascending or "-" for descending. If no prefix is provided, "+" is assumed.""")
+        @QueryParam(value = "sortby") String sortBy,
 
             // --------------------------------------------------------
             // -----------------------  PAGE   -----------------------
@@ -187,7 +201,9 @@ public class StacSearchRESTService extends StacRESTService {
                 .sortBy(sortBy)
                 .from(from.get())
                 .after(after)
-                .before(before);
+                .before(before)
+                .filter(filter)
+                .filterLang(filterLang);
 
         if (!StringUtil.isNullOrEmpty(intersects)) {
             searchBody.setIntersects(GeoUtil.geojsonReader.readValue(intersects));
@@ -208,12 +224,14 @@ public class StacSearchRESTService extends StacRESTService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "A feature collection.",
                     content = @Content(schema = @Schema(implementation = StacFeatureCollection.class))),
-            @ApiResponse(responseCode = "400", description = "Invalid query parameter.",
+            @ApiResponse(responseCode = "400", description = "Invalid request body or query parameter.",
                     content = @Content(schema = @Schema(implementation = Error.class))),
             @ApiResponse(responseCode = "500", description = "Arlas Server Error.",
                     content = @Content(schema = @Schema(implementation = Error.class)))
     })
     public Response postItemSearch(@Context UriInfo uriInfo,
+                                   @NotNull
+                                   @RequestBody(required = true)
                                    @Valid SearchBody<List<SortBy>> body,
 
                                    @Parameter(hidden = true)
@@ -232,11 +250,16 @@ public class StacSearchRESTService extends StacRESTService {
     // -----------
 
     private <T> StacFeatureCollection getItems(String partitionFilter, Optional<String> columnFilter, Optional<String> organisations, UriInfo uriInfo, SearchBody<T> body, String method) throws ArlasException {
-        // TODO search in more than the first collection given as parameter
-        CollectionReference collectionReference = body.getCollections() == null || body.getCollections().isEmpty() ?
-                collectionReferenceService.getAllCollectionReferences(columnFilter, organisations).get(0) :
-                collectionReferenceService.getCollectionReference(body.getCollections().get(0), organisations);
-
+        List<String> collections = body.getCollections();
+        if (collections == null || collections.size() != 1) {
+            throw new BadRequestException(
+                    Response.status(Response.Status.BAD_REQUEST)
+                            .type(MediaType.APPLICATION_JSON)
+                            .entity(new Error(400,"BadRequest", "Provided collections list must contain exactly one element"))
+                            .build()
+            );
+        }
+        CollectionReference collectionReference = collectionReferenceService.getCollectionReference(collections.get(0), organisations);
         return getStacFeatureCollection(collectionReference, partitionFilter, columnFilter, body,
                 getFilter(collectionReference, body), uriInfo, method, false);
     }

--- a/stac-api/src/main/java/io/arlas/server/stac/model/SearchBody.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/model/SearchBody.java
@@ -28,6 +28,9 @@ import java.util.List;
 import java.util.Objects;
 
 public class SearchBody<T>  {
+  public static final String CQL2_TEXT_STRING = "cql2-text";
+  public static final String CQL2_JSON_STRING = "cql2-json";
+
   private @Valid List<Double> bbox;
 
   private @Valid String datetime = null;
@@ -48,14 +51,49 @@ public class SearchBody<T>  {
 
   private @Valid String before = null;
 
+  private @Valid String filter = null;
+
+  private @Valid String filterLang = null;
+
   /**
    **/
-  public SearchBody datetime(String datetime) {
+  public SearchBody<T> datetime(String datetime) {
     this.datetime = datetime;
     return this;
   }
 
-  
+  /**
+   **/
+  public SearchBody<T> filterLang(String filterLang) {
+    this.filterLang = filterLang;
+    return this;
+  }
+
+  @Schema()
+  @JsonProperty("filter-lang")
+  public String getFilterLang() {
+    return filterLang;
+  }
+  public void setFilterLang(String filterLang) {
+    this.filterLang = filterLang;
+  }
+
+  /**
+   **/
+  public SearchBody<T> filter(String filter) {
+    this.filter = filter;
+    return this;
+  }
+
+  @Schema()
+  @JsonProperty("filter")
+  public String getFilter() {
+    return filter;
+  }
+  public void setFilter(String filter) {
+    this.filter = filter;
+  }
+
   @Schema()
   @JsonProperty("datetime")
 
@@ -68,7 +106,7 @@ public class SearchBody<T>  {
 
   /**
    **/
-  public SearchBody intersects(GeoJsonObject intersects) {
+  public SearchBody<T> intersects(GeoJsonObject intersects) {
     this.intersects = intersects;
     return this;
   }
@@ -86,7 +124,7 @@ public class SearchBody<T>  {
 
   /**
    **/
-  public SearchBody bbox(List<Double> bbox) {
+  public SearchBody<T> bbox(List<Double> bbox) {
     this.bbox = bbox;
     return this;
   }
@@ -104,7 +142,7 @@ public class SearchBody<T>  {
 
   /**
    **/
-  public SearchBody collections(List<String> collections) {
+  public SearchBody<T> collections(List<String> collections) {
     this.collections = collections;
     return this;
   }
@@ -122,7 +160,7 @@ public class SearchBody<T>  {
 
   /**
    **/
-  public SearchBody ids(List<String> ids) {
+  public SearchBody<T> ids(List<String> ids) {
     this.ids = ids;
     return this;
   }
@@ -140,7 +178,7 @@ public class SearchBody<T>  {
 
   /**
    **/
-  public SearchBody limit(Integer limit) {
+  public SearchBody<T> limit(Integer limit) {
     this.limit = limit;
     return this;
   }
@@ -158,7 +196,7 @@ public class SearchBody<T>  {
 
   /**
    **/
-  public SearchBody from(Integer from) {
+  public SearchBody<T> from(Integer from) {
     this.from = from;
     return this;
   }
@@ -172,7 +210,7 @@ public class SearchBody<T>  {
 
   /**
    **/
-  public SearchBody sortBy(T sortBy) {
+  public SearchBody<T> sortBy(T sortBy) {
     this.sortBy = sortBy;
     return this;
   }
@@ -190,7 +228,7 @@ public class SearchBody<T>  {
 
   /**
    **/
-  public SearchBody after(String after) {
+  public SearchBody<T> after(String after) {
     this.after = after;
     return this;
   }
@@ -208,7 +246,7 @@ public class SearchBody<T>  {
 
   /**
    **/
-  public SearchBody before(String before) {
+  public SearchBody<T> before(String before) {
     this.before = before;
     return this;
   }
@@ -233,7 +271,7 @@ public class SearchBody<T>  {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SearchBody searchBodyPost = (SearchBody) o;
+    SearchBody<T> searchBodyPost = (SearchBody<T>) o;
     return Objects.equals(datetime, searchBodyPost.datetime) &&
         Objects.equals(intersects, searchBodyPost.intersects) &&
         Objects.equals(collections, searchBodyPost.collections) &&


### PR DESCRIPTION
## Pull Request Objective

This pull request aims to add support for passing filters to the STAC and OGC Features search endpoints available in ARLAS-Server.

It is divided into four commits:

- 1 Updating the JUnit dependency to version 6
- 2 Updating the stac-api module to integrate filters
- 3 Implementing integration tests to validate filter support
- 4 Adding execution of STAC filter-related tests in CI

## 1. Updating JUnit to Version 6

This dependency update enables the use of parameterized test methods within a test class.

- pom.xml files importing JUnit have been updated
- This update introduces the following changes across all existing test files:
  - Replace the `@Test` import
  - Replace `@Before` with `@BeforeEach`
  - Replace `@After` with `@AfterEach`
  - Replace `@BeforeClass` with `@BeforeAll`
  - Replace `@AfterClass` with `@AfterAll`
  - Replace `@FixMethodOrder(MethodSorters.NAME_ASCENDING)` with `@TestMethodOrder(MethodOrderer.MethodName.class)`
  - Remove `@RunWith(Parameterized.class)` at class level in favor of `@ParameterizedTest` and `@MethodSource` at method level

## 2. Updating stac-api Module to Support Filters

The filter implementation impacts three endpoints:

- `/stac/search` (GET)
- `/stac/search` (POST)
- `/collections/{collectionId}/items` (GET)

For each endpoint, the parameters `filter` and `filter-lang` have been added.

The CQL2 filter is applied as an AND condition alongside existing filters: `ids`, `datetime`, `bbox`, `intersects`, as well as ARLAS-specific `partition-filter` and `column-filter`.

ARLAS-Server filters are used to translate CQL2 filters, and GeoTools is used to deserialize them.

Two new files were created:

- `stac-api/src/main/java/io/arlas/server/stac/api/ArlasFilterUtils.java`
  This file contains the method `cql2toArlasFilterList`, which transforms a GeoTools CQL2 filter into an ARLAS filter, with the following specifications:
  - Supported comparison operators: EQ, NEQ, GTE, GTE, LT, LTE, BETWEEN, LIKE, WITHIN, INTERSECT
  - Supports AND combinations
  - Does not support OR or NOT
  - Does not support `%` containing in a LIKE value (due to the ARLAS implementation)
  - Does not support WITHIN with LineString, MultiLineString, or GeometryCollection containing LineString or MultiLineString (due to the Elasticsearch implementation)
  - Supports BBOX

- `stac-api/src/main/java/io/arlas/server/stac/api/CQL2FilterUtils.java`
  This utility file overrides the `CQL2.toFilter` and `CQL2Json.toFilter` methods to work around a known bug: GeoTools transforms BBOX literals into clockwise polygons instead of counter-clockwise.

The following files were modified:

- `stac-api/pom.xml`
  - Added the GeoTools dependency to deserialize CQL2 filters
- `stac-api/src/main/java/io/arlas/server/stac/api/StacCollectionsRESTService.java`
  - Added the `filter` and `filter-lang` parameters for `/collections/{collectionId}/items` (GET)
- `stac-api/src/main/java/io/arlas/server/stac/api/StacRESTService.java`
  - Updated the `getStacFeatureCollection` method to take the new CQL2 filters into account
- `stac-api/src/main/java/io/arlas/server/stac/api/StacSearchRESTService.java`
  - Added the `filter` and `filter-lang` parameters for `/stac/search` in both GET and POST
  - Added an exception when exactly one collection is not provided in the `collections` parameter for `/stac/search` in both GET and POST
- `stac-api/src/main/java/io/arlas/server/stac/model/SearchBody.java`
  - Updated the `SearchBody` model to add `filter` and `filter-lang`

## 3. Implementing Integration Tests to Validate Filter Support

Parameterized tests are used to systematically cover the following six cases:

- `/stac/search` in GET with `filter-lang` CQL-TEXT
- `/stac/search` in GET with `filter-lang` CQL-JSON
- `/stac/search` in POST with `filter-lang` CQL-TEXT
- `/stac/search` in POST with `filter-lang` CQL-JSON
- `/collections/{collectionId}/items` in GET with `filter-lang` CQL-TEXT
- `/collections/{collectionId}/items` in GET with `filter-lang` CQL-JSON

This list is defined in the `scenarioCases` method in `arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceTest.java`.

To validate a test, the number of returned items is checked with `assertReturnedValues`, and the content of returned items is tested where possible with `assertCommonResponse` (for the basic operators EQ, NEQ, GTE, GTE, LT, LTE, LIKE).

All tests are built in the same way: a stream of `scenarioCases(StacFilterScenario)` is provided as a parameter, the test calls `executeRequest`, then `assertCommonResponse`, and finally `assertReturnedValues`.

The following files were created:

- `arlas-tests/src/test/java/io/arlas/server/tests/stac/STACFilterModels.java`
  - This file contains the models used to build the tests. An important model is `StacFilterScenario`, which defines a STAC filter case, and `FilterClause`, which describes a filter.
- `arlas-tests/src/test/java/io/arlas/server/tests/stac/STACFilterSerializer.java`
  - This serializer builds CQL2 text or JSON filters from one or more `FilterClause` objects contained in a `StacFilterScenario`
- `arlas-tests/src/test/java/io/arlas/server/tests/stac/STACRequestFactory.java`
  - This file contains methods used to build the GET and POST parameters to send in the test request from a `StacFilterScenario` and a `filter-lang`
- `arlas-tests/src/test/java/io/arlas/server/tests/stac/STACResponseAssertions.java`
  - This file contains methods used to validate the responses returned by the test requests

- `arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceTest.java`
  - This class extends `AbstractTestContext`, an ARLAS test class used to manipulate collection data. It contains the method to execute requests and the two methods used to validate responses.
- `arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceIT.java`
  - Test file used to validate compliance and the requirement to have one and only one collection in the `collections` parameter
- `arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceBasicFilterIT.java`
  - Tests for operators EQ, NEQ, GTE, GTE, LT, LTE, BETWEEN, LIKE in simple mode (without AND), for string, number, and date types
- `arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceAndFilterIT.java`
  - Tests for operators EQ, NEQ, GTE, GTE, LT, LTE, BETWEEN, LIKE in complex mode with AND
- `arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceFullFilterIT.java`
  - Tests for operators EQ, NEQ, GTE, GTE, LT, LTE, BETWEEN, LIKE in complex mode with AND and with existing STAC filters (`ids`, `datetime`, `bbox`)
- `arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceGeoFilterIT.java`
  - Tests for operators WITHIN and INTERSECT for all geometry types
- `arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceHeaderFilterIT.java`
  - Tests for operators EQ, NEQ, GTE, GTE, LT, LTE, BETWEEN, LIKE in complex mode with AND and the `partition-filter` and `column-filter` filters

## 4. Adding STAC Filter Test Execution to Continuous Integration

The following files were modified:

- `.github/workflows/tests.yaml`
- `scripts/ci/tests-integration-stage.sh` (using `gisaia/stac-api-validator:0.7.2` to work around the new ARLAS specification requiring exactly one collection in a STAC request)
- `scripts/ci/tests-integration.sh`
- `arlas-tests/src/test/java/io/arlas/server/tests/ogc/csw/CSWServiceIT.java`
- `arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceTest.java`

## Remaining Work to Fully Address Ticket #1055

- Write tests using a STAC model collection to validate support for `:` in field names
- Implement and test the `/queryable` endpoints
- Write the documentation
- Write tests derived from the conformance specifications: OGC API Filtering Conformance Tests
