### PR TITLE
Feature/add stac filter eo test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -134,6 +134,19 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
         run: scripts/ci/tests-integration-stage.sh --stage=STAC_FILTER
 
+  run-test-stac-filter-eo:
+    runs-on: ubuntu-latest
+    name: Run tests [STAC-FILTER ARLAS EO]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/workflows/prepare
+      - name: Run tests [STAC-FILTER ARLAS EO]
+        env:
+          # secrets are defined here : https://github.com/organizations/gisaia/settings/secrets/actions
+          DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        run: scripts/ci/tests-integration-stage.sh --stage=STAC_FILTER_ARLASEO
+
   run-test-stac-eo:
     runs-on: ubuntu-latest
     name: Run tests [STAC ARLAS EO]

--- a/arlas-tests/src/test/java/io/arlas/server/tests/DataStacGenerator.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/DataStacGenerator.java
@@ -28,8 +28,8 @@ public class DataStacGenerator {
     private static final int NUM_FEATURES = 60;
     private static final long SEED = 12345L;
     private static final Random random = new Random(SEED);
-    private static final Calendar c = Calendar.getInstance();
-
+    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    private static final Calendar c = Calendar.getInstance(UTC);
     public static List<DataStac> generateDataStacList() {
         List<DataStac> features = new ArrayList<>();
         for (int i = 0; i < NUM_FEATURES; i++) {

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceEOTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceEOTest.java
@@ -26,18 +26,17 @@ import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 
-public class AbstractSTACServiceTest extends AbstractSTACTestContext {
+public class AbstractSTACServiceEOTest extends AbstractSTACTestContext {
 
     @BeforeAll
     public static void beforeClass() throws ArlasException {
         // Exclude fields from the collection: false
         // Include a datetime field in the mapping: true
-        // Indicates whether the collection refers to a STAC model: false
-        new CollectionTool().load(10000,false,true,false);
+        // Indicates whether the collection refers to a STAC model: true
+        new CollectionTool().load(10000,false,true,true);
     }
-
     @AfterAll
     public static void afterClass() throws IOException, ArlasException {
-        new CollectionTool().delete(true);
+        new CollectionTool().delete(false);
     }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACServiceTest.java
@@ -19,185 +19,22 @@
 
 package io.arlas.server.tests.stac;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.arlas.commons.exceptions.InvalidParameterException;
-import io.arlas.server.core.model.request.Filter;
-import io.arlas.server.stac.model.SearchBody;
-import io.arlas.server.tests.AbstractTestContext;
-import io.restassured.response.ValidatableResponse;
-import io.restassured.specification.RequestSpecification;
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.params.provider.Arguments;
-import org.locationtech.jts.io.ParseException;
+import io.arlas.commons.exceptions.ArlasException;
+import io.arlas.server.tests.CollectionTool;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.stream.Stream;
 
-import static io.arlas.commons.rest.utils.ServerConstants.COLUMN_FILTER;
-import static io.arlas.commons.rest.utils.ServerConstants.PARTITION_FILTER;
-import static io.restassured.RestAssured.given;
-import static io.arlas.server.tests.stac.STACFilterModels.FilterLang;
-import static io.arlas.server.tests.stac.STACFilterModels.RequestTarget;
-import static io.arlas.server.tests.stac.STACFilterModels.StacFilterScenario;
-import static io.arlas.server.tests.stac.STACFilterModels.TypeOfGet;
+public class AbstractSTACServiceTest extends AbstractSTACTestContext {
 
-public class AbstractSTACServiceTest extends AbstractTestContext {
-
-    public static final String COLLECTION = "geodata";
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    protected final STACRequestFactory requestFactory = new STACRequestFactory(COLLECTION);
-    protected final STACResponseAssertions responseAssertions = new STACResponseAssertions();
-
-    public final List<String> arlasConformsTo = List.of(
-            "https://api.stacspec.org/v1.0.0/core",
-            "https://api.stacspec.org/v1.0.0-beta.2/core",
-            "https://api.stacspec.org/v1.0.0/item-search",
-            "https://api.stacspec.org/v1.0.0/ogcapi-features",
-            "https://api.stacspec.org/v1.0.0/collections",
-            "https://api.stacspec.org/v1.0.0/item-search#sort",
-            "https://api.stacspec.org/v1.0.0/item-search#context",
-            "https://api.stacspec.org/v1.0.0/item-search#filter",
-            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
-            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
-            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
-            "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
-            "http://www.opengis.net/spec/cql2/1.0/conf/cql2-json",
-            "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
-            "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions",
-            "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions-plus"
-    );
-
-    @Override
-    protected String getUrlPath(String collection) {
-        return arlasPath + "stac/collections/" + collection + "/items";
+    @BeforeAll
+    public static void beforeClass() throws ArlasException {
+        new CollectionTool().load(10000,false,true,false);
     }
 
-    protected String getUrlStacSearchPath() {
-        return arlasPath + "stac/search";
-    }
-
-    protected String getUrlStacPath() {
-        return arlasPath + "stac";
-    }
-
-    protected RequestSpecification givenFilterableRequestParams() {
-        return given().contentType("application/json;charset=utf-8");
-    }
-
-    protected ValidatableResponse get(
-            List<Pair<String, String>> params,
-            Filter headerFilter,
-            String columnFilter,
-            TypeOfGet typeOfGet
-    ) throws JsonProcessingException {
-        RequestSpecification req = givenFilterableRequestParams();
-
-        for (Pair<String, String> param : params) {
-            req = req.param(param.getKey(), param.getValue());
-        }
-
-        if (headerFilter != null) {
-            req = req.header(PARTITION_FILTER, OBJECT_MAPPER.writeValueAsString(headerFilter));
-        }
-
-        if (columnFilter != null) {
-            req = req.header(COLUMN_FILTER, columnFilter);
-        }
-
-        if (typeOfGet == TypeOfGet.OGC_FEATURE) {
-            return req.when().get(getUrlPath(COLLECTION)).then();
-        }
-        return req.when().get(getUrlStacSearchPath()).then();
-    }
-
-    protected ValidatableResponse post(
-            SearchBody<Object> body,
-            Filter headerFilter,
-            String columnFilter
-    ) throws JsonProcessingException {
-        RequestSpecification req = givenFilterableRequestParams();
-
-        if (headerFilter != null) {
-            req = req.header(PARTITION_FILTER, OBJECT_MAPPER.writeValueAsString(headerFilter));
-        }
-
-        if (columnFilter != null) {
-            req = req.header(COLUMN_FILTER, columnFilter);
-        }
-
-        return req.body(body).when().post(getUrlStacSearchPath()).then();
-    }
-
-    public static Stream<Arguments> scenarioCases(StacFilterScenario scenario) {
-        return Stream.of(
-                Arguments.of(label(scenario, RequestTarget.stacGet(), FilterLang.CQL2_TEXT), scenario, RequestTarget.stacGet(), FilterLang.CQL2_TEXT),
-                Arguments.of(label(scenario, RequestTarget.stacGet(), FilterLang.CQL2_JSON), scenario, RequestTarget.stacGet(), FilterLang.CQL2_JSON),
-                Arguments.of(label(scenario, RequestTarget.ogcGet(), FilterLang.CQL2_TEXT), scenario, RequestTarget.ogcGet(), FilterLang.CQL2_TEXT),
-                Arguments.of(label(scenario, RequestTarget.ogcGet(), FilterLang.CQL2_JSON), scenario, RequestTarget.ogcGet(), FilterLang.CQL2_JSON),
-                Arguments.of(label(scenario, RequestTarget.post(), FilterLang.CQL2_TEXT), scenario, RequestTarget.post(), FilterLang.CQL2_TEXT),
-                Arguments.of(label(scenario, RequestTarget.post(), FilterLang.CQL2_JSON), scenario, RequestTarget.post(), FilterLang.CQL2_JSON)
-        );
-    }
-
-    public static String label(StacFilterScenario scenario, RequestTarget target, FilterLang lang) {
-        String filterLabel = scenario.clauses().stream()
-                .map(c -> "%s %s %s".formatted(c.property(), c.operator().symbol(), c.value()))
-                .reduce((a, b) -> a + " AND " + b)
-                .orElse("");
-
-        String extras = "";
-        if (scenario.partitionFilter() != null || scenario.columnFilter() != null
-                || scenario.ids() != null || scenario.datetime() != null || scenario.bbox() != null) {
-            extras = " | partitionFilter=%s | columnFilter=%s | ids=%s | datetime=%s | bbox=%s"
-                    .formatted(
-                            scenario.partitionFilter() != null ? scenario.partitionFilter().f.toString() : null,
-                            scenario.columnFilter(),
-                            scenario.ids(),
-                            scenario.datetime(),
-                            scenario.bbox()
-                    );
-        }
-
-        return "%s | %s | filter=%s | limit=%d%s"
-                .formatted(target, lang.value(), filterLabel, scenario.limit(), extras);
-    }
-
-    public ValidatableResponse executeRequest(
-            StacFilterScenario scenario,
-            RequestTarget target,
-            FilterLang lang
-    ) throws IOException, InvalidParameterException, ParseException {
-        return switch (target.mode()) {
-            case GET -> get(
-                    requestFactory.buildGetParams(scenario, lang),
-                    scenario.partitionFilter(),
-                    scenario.columnFilter(),
-                    target.typeOfGet()
-            );
-            case POST -> post(
-                    requestFactory.buildSearchBody(scenario, lang),
-                    scenario.partitionFilter(),
-                    scenario.columnFilter()
-            );
-        };
-    }
-
-    protected void assertCommonResponse(
-            ValidatableResponse response,
-            StacFilterScenario scenario,
-            RequestTarget target
-    ) {
-        responseAssertions.assertCommonResponse(response, scenario.expectedMatched(), target);
-    }
-
-    protected void assertReturnedValues(
-            ValidatableResponse response,
-            StacFilterScenario scenario
-    ) {
-        responseAssertions.assertClauses(response, scenario.clauses());
+    @AfterAll
+    public static void afterClass() throws IOException, ArlasException {
+        new CollectionTool().delete(true);
     }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACTestContext.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACTestContext.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.arlas.commons.exceptions.InvalidParameterException;
+import io.arlas.server.core.model.request.Filter;
+import io.arlas.server.stac.model.SearchBody;
+import io.arlas.server.tests.AbstractTestContext;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.params.provider.Arguments;
+import org.locationtech.jts.io.ParseException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static io.arlas.commons.rest.utils.ServerConstants.COLUMN_FILTER;
+import static io.arlas.commons.rest.utils.ServerConstants.PARTITION_FILTER;
+import static io.restassured.RestAssured.given;
+import static io.arlas.server.tests.stac.STACFilterModels.FilterLang;
+import static io.arlas.server.tests.stac.STACFilterModels.RequestTarget;
+import static io.arlas.server.tests.stac.STACFilterModels.StacFilterScenario;
+import static io.arlas.server.tests.stac.STACFilterModels.TypeOfGet;
+
+public class AbstractSTACTestContext extends AbstractTestContext {
+
+    public static final String COLLECTION = "geodata";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    protected final STACRequestFactory requestFactory = new STACRequestFactory(COLLECTION);
+    protected final STACResponseAssertions responseAssertions = new STACResponseAssertions();
+
+    public final List<String> arlasConformsTo = List.of(
+            "https://api.stacspec.org/v1.0.0/core",
+            "https://api.stacspec.org/v1.0.0-beta.2/core",
+            "https://api.stacspec.org/v1.0.0/item-search",
+            "https://api.stacspec.org/v1.0.0/ogcapi-features",
+            "https://api.stacspec.org/v1.0.0/collections",
+            "https://api.stacspec.org/v1.0.0/item-search#sort",
+            "https://api.stacspec.org/v1.0.0/item-search#context",
+            "https://api.stacspec.org/v1.0.0/item-search#filter",
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
+            "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
+            "http://www.opengis.net/spec/cql2/1.0/conf/cql2-json",
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions",
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions-plus"
+    );
+
+    @Override
+    protected String getUrlPath(String collection) {
+        return arlasPath + "stac/collections/" + collection + "/items";
+    }
+
+    protected String getUrlStacSearchPath() {
+        return arlasPath + "stac/search";
+    }
+
+    protected String getUrlStacPath() {
+        return arlasPath + "stac";
+    }
+
+    protected RequestSpecification givenFilterableRequestParams() {
+        return given().contentType("application/json;charset=utf-8");
+    }
+
+    protected ValidatableResponse get(
+            List<Pair<String, String>> params,
+            Filter headerFilter,
+            String columnFilter,
+            TypeOfGet typeOfGet
+    ) throws JsonProcessingException {
+        RequestSpecification req = givenFilterableRequestParams();
+
+        for (Pair<String, String> param : params) {
+            req = req.param(param.getKey(), param.getValue());
+        }
+
+        if (headerFilter != null) {
+            req = req.header(PARTITION_FILTER, OBJECT_MAPPER.writeValueAsString(headerFilter));
+        }
+
+        if (columnFilter != null) {
+            req = req.header(COLUMN_FILTER, columnFilter);
+        }
+
+        if (typeOfGet == TypeOfGet.OGC_FEATURE) {
+            return req.when().get(getUrlPath(COLLECTION)).then();
+        }
+        return req.when().get(getUrlStacSearchPath()).then();
+    }
+
+    protected ValidatableResponse post(
+            SearchBody<Object> body,
+            Filter headerFilter,
+            String columnFilter
+    ) throws JsonProcessingException {
+        RequestSpecification req = givenFilterableRequestParams();
+
+        if (headerFilter != null) {
+            req = req.header(PARTITION_FILTER, OBJECT_MAPPER.writeValueAsString(headerFilter));
+        }
+
+        if (columnFilter != null) {
+            req = req.header(COLUMN_FILTER, columnFilter);
+        }
+
+        return req.body(body).when().post(getUrlStacSearchPath()).then();
+    }
+
+    public static Stream<Arguments> scenarioCases(StacFilterScenario scenario) {
+        return Stream.of(
+                Arguments.of(label(scenario, RequestTarget.stacGet(), FilterLang.CQL2_TEXT), scenario, RequestTarget.stacGet(), FilterLang.CQL2_TEXT),
+                Arguments.of(label(scenario, RequestTarget.stacGet(), FilterLang.CQL2_JSON), scenario, RequestTarget.stacGet(), FilterLang.CQL2_JSON),
+                Arguments.of(label(scenario, RequestTarget.ogcGet(), FilterLang.CQL2_TEXT), scenario, RequestTarget.ogcGet(), FilterLang.CQL2_TEXT),
+                Arguments.of(label(scenario, RequestTarget.ogcGet(), FilterLang.CQL2_JSON), scenario, RequestTarget.ogcGet(), FilterLang.CQL2_JSON),
+                Arguments.of(label(scenario, RequestTarget.post(), FilterLang.CQL2_TEXT), scenario, RequestTarget.post(), FilterLang.CQL2_TEXT),
+                Arguments.of(label(scenario, RequestTarget.post(), FilterLang.CQL2_JSON), scenario, RequestTarget.post(), FilterLang.CQL2_JSON)
+        );
+    }
+
+    public static String label(StacFilterScenario scenario, RequestTarget target, FilterLang lang) {
+        String filterLabel = scenario.clauses().stream()
+                .map(c -> "%s %s %s".formatted(c.property(), c.operator().symbol(), c.value()))
+                .reduce((a, b) -> a + " AND " + b)
+                .orElse("");
+
+        String extras = "";
+        if (scenario.partitionFilter() != null || scenario.columnFilter() != null
+                || scenario.ids() != null || scenario.datetime() != null || scenario.bbox() != null) {
+            extras = " | partitionFilter=%s | columnFilter=%s | ids=%s | datetime=%s | bbox=%s"
+                    .formatted(
+                            scenario.partitionFilter() != null ? scenario.partitionFilter().f.toString() : null,
+                            scenario.columnFilter(),
+                            scenario.ids(),
+                            scenario.datetime(),
+                            scenario.bbox()
+                    );
+        }
+
+        return "%s | %s | filter=%s | limit=%d%s"
+                .formatted(target, lang.value(), filterLabel, scenario.limit(), extras);
+    }
+
+    public ValidatableResponse executeRequest(
+            StacFilterScenario scenario,
+            RequestTarget target,
+            FilterLang lang
+    ) throws IOException, InvalidParameterException, ParseException {
+        return switch (target.mode()) {
+            case GET -> get(
+                    requestFactory.buildGetParams(scenario, lang),
+                    scenario.partitionFilter(),
+                    scenario.columnFilter(),
+                    target.typeOfGet()
+            );
+            case POST -> post(
+                    requestFactory.buildSearchBody(scenario, lang),
+                    scenario.partitionFilter(),
+                    scenario.columnFilter()
+            );
+        };
+    }
+
+    protected void assertCommonResponse(
+            ValidatableResponse response,
+            StacFilterScenario scenario,
+            RequestTarget target
+    ) {
+        responseAssertions.assertCommonResponse(response, scenario.expectedMatched(), target);
+    }
+
+    protected void assertReturnedValues(
+            ValidatableResponse response,
+            StacFilterScenario scenario
+    ) {
+        responseAssertions.assertClauses(response, scenario.clauses(), false);
+    }
+
+    protected void assertReturnedValues(
+            ValidatableResponse response,
+            StacFilterScenario scenario, Boolean isStacModel
+    ) {
+        responseAssertions.assertClauses(response, scenario.clauses(), isStacModel);
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACFilterModels.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACFilterModels.java
@@ -185,7 +185,7 @@ public final class STACFilterModels {
             Object upper
     ) { }
 
-    record BboxValue(
+    public record BboxValue(
             double minX,
             double minY,
             double maxX,

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACResponseAssertions.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACResponseAssertions.java
@@ -23,15 +23,19 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.hamcrest.Matcher;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static io.arlas.server.tests.stac.STACFilterModels.FilterClause;
 import static io.arlas.server.tests.stac.STACFilterModels.RequestTarget;
 import static io.arlas.server.tests.stac.STACFilterModels.TypeOfGet;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
 
 public class STACResponseAssertions {
-
+    private static final List<String> ROOT_STAC_FIELD = List.of("collection", "catalog", "id", "geometry", "bbox", "centroid", "type");
+    private static final List<String> ROOT_STAC_KEY = List.of("properties.", "assets.");
     public void assertCommonResponse(
             ValidatableResponse response,
             int expectedMatched,
@@ -49,28 +53,91 @@ public class STACResponseAssertions {
 
     public void assertClauses(
             ValidatableResponse response,
-            List<FilterClause> clauses
+            List<FilterClause> clauses,
+            Boolean isStacModel
     ) {
         for (FilterClause clause : clauses) {
-            assertClause(response, clause);
+            assertClause(response, clause, isStacModel);
         }
     }
 
-    private void assertClause(
-            ValidatableResponse response,
-            FilterClause clause
-    ) {
-        String path = "features.properties." + clause.property();
-
-        switch (clause.operator()) {
-            case EQ -> response.body(path, everyItem(equalTo(clause.value())));
-            case NE -> response.body(path, everyItem(not(equalTo(clause.value()))));
-            case GT -> response.body(path, everyItem(greaterThanValue(clause.value())));
-            case GTE -> response.body(path, everyItem(greaterThanOrEqualToValue(clause.value())));
-            case LT -> response.body(path, everyItem(lessThanValue(clause.value())));
-            case LTE -> response.body(path, everyItem(lessThanOrEqualToValue(clause.value())));
-            case LIKE -> response.body(path, everyItem(containsString(String.valueOf(clause.value()))));
+    private void assertClause(ValidatableResponse response, FilterClause clause, Boolean isStacModel) {
+        if (Boolean.TRUE.equals(isStacModel)) {
+            List<Object> values = extractSTACValues(response, clause.property());
+            assertThat(values, everyItem(matcherFor(clause)));
+            return;
         }
+
+        String path = "features.properties." + clause.property();
+        response.body(path, everyItem(matcherFor(clause)));
+    }
+
+    private List<Object> extractSTACValues(ValidatableResponse response, String property) {
+        String normalizedProperty = normalizeSTACProperty(property);
+        String quotedPath = quotePath(normalizedProperty);
+        List<Object> rawList = response.extract().jsonPath().getList(quotedPath);
+        return flattenNonNull(rawList);
+    }
+
+    private String normalizeSTACProperty(String property) {
+        if (!ROOT_STAC_FIELD.contains(property) &&
+                ROOT_STAC_KEY.stream().noneMatch(property::startsWith)) {
+            return "properties." + property;
+        }
+        return property;
+    }
+
+    private List<Object> flattenNonNull(List<Object> rawList) {
+        List<Object> cleanList = new ArrayList<>();
+        if (rawList == null) {
+            return cleanList;
+        }
+        for (Object obj : rawList) {
+            if (obj instanceof List<?> list) {
+                for (Object subObj : list) {
+                    if (subObj != null) {
+                        cleanList.add(subObj);
+                    }
+                }
+            } else if (obj != null) {
+                cleanList.add(obj);
+            }
+        }
+        return cleanList;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Matcher matcherFor(FilterClause clause) {
+        Object value = clause.value();
+        return switch (clause.operator()) {
+            case EQ -> equalTo(value);
+            case NE -> not(equalTo(value));
+            case GT -> greaterThanValue(value);
+            case GTE -> greaterThanOrEqualToValue(value);
+            case LT -> lessThanValue(value);
+            case LTE -> lessThanOrEqualToValue(value);
+            case LIKE -> containsString(String.valueOf(value));
+            case ST_INTERSECTS ->  equalTo(true);
+            case ST_WITHIN -> equalTo(true);
+            case BBOX ->  equalTo(true);
+            case BETWEEN -> {
+                if (value instanceof STACFilterModels.BetweenValue v) {
+                    yield allOf(greaterThanOrEqualToValue(v.lower()),lessThanOrEqualToValue(v.upper())) ;
+                } else {
+                    yield equalTo(true);
+                }
+            }
+        };
+    }
+
+    private static String quotePath(String path) {
+        if (path == null || path.isBlank()) {
+            return path;
+        }
+        if (path.contains("\"")) {
+            return path;
+        }
+        return "\"" + path.replace(".", "\".\"") + "\"";
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceBasicFilterIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceBasicFilterIT.java
@@ -86,12 +86,13 @@ public class STACServiceBasicFilterIT extends AbstractSTACServiceTest {
             FilterLang lang
     ) throws Exception {
         ValidatableResponse response = executeRequest(scenario, target, lang);
-        response.assertThat().statusCode(200);
+        assertCommonResponse(response, scenario,target);
+        assertReturnedValues(response, scenario);
 
     }
     static Stream<Arguments> filterLikeEscapeCases() {
         return Stream.of(
-                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.LIKE, "\\%cto", 60, 59))
+                scenarioCases(StacFilterScenario.simple("params.job", FilterOperator.LIKE, "\\%cto", 60, 0))
         ).flatMap(s -> s);
     }
 

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceEoIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceEoIT.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.server.tests.stac;
+
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+public class STACServiceEoIT extends AbstractSTACServiceEOTest {
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("filterEoCloudCoverCases")
+    public void testEoCloudCoverFilter(
+            String label,
+            STACFilterModels.StacFilterScenario scenario,
+            STACFilterModels.RequestTarget target,
+            STACFilterModels.FilterLang lang
+    ) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario,target);
+        assertReturnedValues(response, scenario,true);
+    }
+    static Stream<Arguments> filterEoCloudCoverCases() {
+        return Stream.of("eo:cloud_cover","properties.eo:cloud_cover").flatMap(property -> Stream.of(
+                scenarioCases(STACFilterModels.StacFilterScenario.simple(property, STACFilterModels.FilterOperator.EQ, 83.309135F, 100, 1)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple(property, STACFilterModels.FilterOperator.NE, 83.309135F, 100, 59)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple(property, STACFilterModels.FilterOperator.GT, 50F, 100, 29)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple(property, STACFilterModels.FilterOperator.GTE, 50F, 100, 29)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple(property, STACFilterModels.FilterOperator.GTE, 0F, 100, 60)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple(property, STACFilterModels.FilterOperator.LT, 50F, 100, 31)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple(property, STACFilterModels.FilterOperator.LTE, 50F, 100, 31)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple(property, STACFilterModels.FilterOperator.BETWEEN, new STACFilterModels.BetweenValue(0,25), 100, 16))
+        )).flatMap(s -> s);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("filterGeometryCases")
+    public void testGeometryFilter(
+            String label,
+            STACFilterModels.StacFilterScenario scenario,
+            STACFilterModels.RequestTarget target,
+            STACFilterModels.FilterLang lang
+    ) throws Exception {
+        ValidatableResponse response = executeRequest(scenario, target, lang);
+        assertCommonResponse(response, scenario,target);
+        assertReturnedValues(response, scenario,true);
+    }
+    static Stream<Arguments> filterGeometryCases() {
+        return Stream.of(
+                scenarioCases(STACFilterModels.StacFilterScenario.simple("geometry", STACFilterModels.FilterOperator.ST_WITHIN, "POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))", 100, 0)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple("geometry", STACFilterModels.FilterOperator.ST_INTERSECTS, "POLYGON((-20 -20, 20 -20, 20 20, -20 20, -20 -20))", 100, 4)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple("geometry", STACFilterModels.FilterOperator.BBOX, new STACFilterModels.BboxValue(-20,-20,20,20), 100, 4)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple("geometry", STACFilterModels.FilterOperator.BBOX, new STACFilterModels.BboxValue(-50,-50,50,50), 100, 25)),
+                scenarioCases(STACFilterModels.StacFilterScenario.simple("geometry", STACFilterModels.FilterOperator.BBOX, new STACFilterModels.BboxValue(-20,-20,20,20), 100, 4).withBbox("-50,-50,50,50"))
+                ).flatMap(s -> s);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <!-- JAXB RUNTIME -->
         <jaxb-runtime.version>4.0.7</jaxb-runtime.version>
         <!-- JACKSON CORE -->
-        <jackson.core.version>2.21.1</jackson.core.version>
+        <jackson.core.version>2.21.4</jackson.core.version>
     </properties>
     <dependencies>
         <dependency>
@@ -94,6 +94,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
+                <version>${jackson.core.version}</version>
+            </dependency>
+            <!-- TO FIX CVE-2026-54512 and CVE-2026-54513  -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
                 <version>${jackson.core.version}</version>
             </dependency>
             <!-- TO FIX CVE-2026-2332  -->

--- a/scripts/ci/tests-integration-stage.sh
+++ b/scripts/ci/tests-integration-stage.sh
@@ -189,6 +189,12 @@ function test_wfs() {
 }
 
 function test_stac_filter() {
+    export ARLAS_PREFIX="/arlastest"
+    export ARLAS_APP_PATH="/pathtest"
+    export ARLAS_BASE_URI="http://arlas-server:9999/pathtest/arlastest/"
+    export ARLAS_SERVICE_STAC_ENABLE=true
+    export ARLAS_INSPIRE_ENABLED=true
+    start_stack
     docker run --rm \
         -w /opt/maven \
         -v $PWD:/opt/maven \
@@ -202,7 +208,31 @@ function test_stac_filter() {
         -e ALIASED_COLLECTION=${ALIASED_COLLECTION} \
         --net arlas_default \
         maven:3.8.5-openjdk-17 \
-        mvn "-Dit.test=STACService*IT" verify -DskipTests=false -DfailIfNoTests=false -B
+        mvn "-Dit.test=STACService*IT,!STACService*EoIT" verify -DskipTests=false -DfailIfNoTests=false -B
+}
+
+function test_stac_filter_arlas_eo() {
+      export ARLAS_PREFIX="/arlastest"
+      export ARLAS_APP_PATH="/pathtest"
+      export ARLAS_BASE_URI="http://arlas-server:9999/pathtest/arlastest/"
+      export ARLAS_SERVICE_STAC_ENABLE=true
+      export ARLAS_INSPIRE_ENABLED=true
+      start_stack
+      docker run --rm \
+          -w /opt/maven \
+          -v $PWD:/opt/maven \
+          -v $HOME/.m2:/root/.m2 \
+          -e ARLAS_HOST="arlas-server" \
+          -e ARLAS_PORT="9999" \
+          -e ARLAS_PREFIX=${ARLAS_PREFIX} \
+          -e ARLAS_APP_PATH=${ARLAS_APP_PATH} \
+          -e ARLAS_INSPIRE_ENABLED=${ARLAS_INSPIRE_ENABLED}\
+          -e ARLAS_ELASTIC_NODES="elasticsearch:9200" \
+          -e ALIASED_COLLECTION=${ALIASED_COLLECTION} \
+          --net arlas_default \
+          maven:3.8.5-openjdk-17 \
+          mvn "-Dit.test=STACService*EoIT" verify -DskipTests=false -DfailIfNoTests=false -B
+
 }
 
 function test_stac() {
@@ -323,6 +353,7 @@ if [ "$STAGE" == "WFS" ]; then export ALIASED_COLLECTION="false"; export WKT_GEO
 if [ "$STAGE" == "CSW" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_csw; fi
 if [ "$STAGE" == "STAC" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_stac "loadstac" "delete"; fi
 if [ "$STAGE" == "STAC_FILTER" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_stac_filter ;  fi
+if [ "$STAGE" == "STAC_FILTER_ARLASEO" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_stac_filter_arlas_eo ;  fi
 if [ "$STAGE" == "REST_WKT_GEOMETRIES" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="true"; test_rest; fi
 if [ "$STAGE" == "REST_ALIASED" ]; then export ALIASED_COLLECTION="true"; export WKT_GEOMETRIES="false"; test_rest; fi
 if [ "$STAGE" == "WFS_ALIASED" ]; then export ALIASED_COLLECTION="true"; export WKT_GEOMETRIES="false"; test_wfs; fi

--- a/scripts/ci/tests-integration-stage.sh
+++ b/scripts/ci/tests-integration-stage.sh
@@ -188,30 +188,7 @@ function test_wfs() {
         mvn exec:java -Dexec.mainClass="io.arlas.server.tests.CollectionTool" -Dexec.classpathScope=test -Dexec.args="delete" -pl arlas-tests -B
 }
 
-
-
 function test_stac_filter() {
-    export ARLAS_PREFIX="/arlastest"
-    export ARLAS_APP_PATH="/pathtest"
-    export ARLAS_BASE_URI="http://arlas-server:9999/pathtest/arlastest/"
-    export ARLAS_SERVICE_STAC_ENABLE=true
-    export ARLAS_INSPIRE_ENABLED=true
-    start_stack
-    docker run --rm \
-        -w /opt/maven \
-        -v $PWD:/opt/maven \
-        -v $HOME/.m2:/root/.m2 \
-        -e ARLAS_HOST="arlas-server" \
-        -e ARLAS_PORT="9999" \
-        -e ARLAS_PREFIX=${ARLAS_PREFIX} \
-        -e ARLAS_APP_PATH=${ARLAS_APP_PATH} \
-        -e ARLAS_INSPIRE_ENABLED=${ARLAS_INSPIRE_ENABLED} \
-        -e ARLAS_ELASTIC_NODES="elasticsearch:9200" \
-        -e ALIASED_COLLECTION=${ALIASED_COLLECTION} \
-        --net arlas_default \
-        maven:3.8.5-openjdk-17 \
-        mvn exec:java -Dexec.mainClass="io.arlas.server.tests.CollectionTool" -Dexec.classpathScope=test -Dexec.args="$1" -pl arlas-tests -B
-
     docker run --rm \
         -w /opt/maven \
         -v $PWD:/opt/maven \
@@ -226,22 +203,7 @@ function test_stac_filter() {
         --net arlas_default \
         maven:3.8.5-openjdk-17 \
         mvn "-Dit.test=STACService*IT" verify -DskipTests=false -DfailIfNoTests=false -B
-
-    docker run --rm \
-        -w /opt/maven \
-        -v $PWD:/opt/maven \
-        -v $HOME/.m2:/root/.m2 \
-        -e ARLAS_HOST="arlas-server" \
-        -e ARLAS_PORT="9999" \
-        -e ARLAS_PREFIX=${ARLAS_PREFIX} \
-        -e ARLAS_APP_PATH=${ARLAS_APP_PATH} \
-        -e ARLAS_ELASTIC_NODES="elasticsearch:9200" \
-        -e ALIASED_COLLECTION=${ALIASED_COLLECTION} \
-        --net arlas_default \
-        maven:3.8.5-openjdk-17 \
-        mvn exec:java -Dexec.mainClass="io.arlas.server.tests.CollectionTool" -Dexec.classpathScope=test -Dexec.args="$2" -pl arlas-tests -B
 }
-
 
 function test_stac() {
     export ARLAS_PREFIX="/arlastest"
@@ -360,7 +322,7 @@ if [ "$STAGE" == "REST" ]; then export ALIASED_COLLECTION="false"; export WKT_GE
 if [ "$STAGE" == "WFS" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_wfs; fi
 if [ "$STAGE" == "CSW" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_csw; fi
 if [ "$STAGE" == "STAC" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_stac "loadstac" "delete"; fi
-if [ "$STAGE" == "STAC_FILTER" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_stac_filter "loadstac" "delete";  fi
+if [ "$STAGE" == "STAC_FILTER" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="false"; test_stac_filter ;  fi
 if [ "$STAGE" == "REST_WKT_GEOMETRIES" ]; then export ALIASED_COLLECTION="false"; export WKT_GEOMETRIES="true"; test_rest; fi
 if [ "$STAGE" == "REST_ALIASED" ]; then export ALIASED_COLLECTION="true"; export WKT_GEOMETRIES="false"; test_rest; fi
 if [ "$STAGE" == "WFS_ALIASED" ]; then export ALIASED_COLLECTION="true"; export WKT_GEOMETRIES="false"; test_wfs; fi

--- a/stac-api/src/main/java/io/arlas/server/stac/api/ArlasFilterUtils.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/ArlasFilterUtils.java
@@ -22,6 +22,8 @@ package io.arlas.server.stac.api;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.geojson.Polygon;
 import org.geotools.api.filter.*;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.api.filter.expression.Literal;
@@ -41,6 +43,9 @@ import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.geom.GeometryCollection;
 
 public class ArlasFilterUtils {
+
+    private static final List<String> ROOT_STAC_FIELD = List.of("collection", "catalog", "id", "geometry", "bbox", "centroid", "type");
+    private static final List<String> ROOT_STAC_KEY = List.of("properties.", "assets.");
 
     public static List<String> cql2toArlasFilterList(Filter filter, Boolean isStacModel) throws ArlasException {
         List<String> filters = new ArrayList<>();
@@ -220,17 +225,22 @@ public class ArlasFilterUtils {
         return StringUtil.concat(property, ":", arlasOperator, ":", value);
     }
 
+
+
     private static String normalizeProperty(String property, Boolean isStacModel) {
         String normalized = property.replace('/', '.');
         if (Boolean.TRUE.equals(isStacModel)) {
             normalized = normalized.replaceFirst(":", "__");
+            if(!ROOT_STAC_FIELD.contains(normalized) && ROOT_STAC_KEY.stream().noneMatch(normalized::startsWith)) {
+                normalized = "properties." + normalized;
+            }
         }
         return normalized;
     }
 
     /**
      * Validates LIKE literal to reject unescaped leading wildcards.
-     * - Exception if pattern starts with an unescaped wildcard (default '%').
+     * - Exception if pattern contains with an unescaped wildcard (default '%').
      * - Allowed if the leading wildcard is escaped with the escape character.
      */
     private static void validateLikeLiteral(PropertyIsLike like) throws InvalidParameterException {
@@ -240,10 +250,10 @@ public class ArlasFilterUtils {
         }
         String wildCard = "%";
         String escape = like.getEscape();
-        if (escape != null && !escape.isEmpty() && literal.startsWith(escape + wildCard)) {
+        if (escape != null && !escape.isEmpty() && literal.contains(escape + wildCard)) {
             return;
         }
-        if (literal.startsWith(wildCard)) {
+        if (literal.contains(wildCard)) {
             throw new InvalidParameterException("LIKE filters starting with an unescaped wildcard are not supported");
         }
     }


### PR DESCRIPTION
- Refactor AbstractSTACServiceTest to AbstracSTACTestContext to use it in AbstractSTACServiceEOTest
- Add tests on STAC Filter with a STAC EO model collection (case of :, with or without prefix properties.)
- Change _startWith_ with _contains_ to rise exception with LIKE operator