### PR TITLE
Feature/queryable as query param

### DIFF
--- a/arlas-tests/pom.xml
+++ b/arlas-tests/pom.xml
@@ -38,6 +38,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
             <version>${jts.version}</version>

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACTestContext.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/AbstractSTACTestContext.java
@@ -69,7 +69,9 @@ public class AbstractSTACTestContext extends AbstractTestContext {
             "http://www.opengis.net/spec/cql2/1.0/conf/cql2-json",
             "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
             "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions",
-            "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions-plus"
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions-plus",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables-query-parameters"
     );
 
     @Override
@@ -174,7 +176,7 @@ public class AbstractSTACTestContext extends AbstractTestContext {
     ) throws IOException, InvalidParameterException, ParseException {
         return switch (target.mode()) {
             case GET -> get(
-                    requestFactory.buildGetParams(scenario, lang),
+                    requestFactory.buildGetParams(scenario, lang, target.typeOfGet()),
                     scenario.partitionFilter(),
                     scenario.columnFilter(),
                     target.typeOfGet()

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACRequestFactory.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACRequestFactory.java
@@ -44,10 +44,13 @@ public class STACRequestFactory {
 
     public List<Pair<String, String>> buildGetParams(
             StacFilterScenario scenario,
-            FilterLang lang
+            FilterLang lang,
+            STACFilterModels.TypeOfGet typeOfGet
     ) throws ParseException, IOException {
         List<Pair<String, String>> params = new ArrayList<>();
-        params.add(new ImmutablePair<>("collections", collection));
+        if(typeOfGet.equals(STACFilterModels.TypeOfGet.STAC)){
+            params.add(new ImmutablePair<>("collections", collection));
+        }
         params.add(new ImmutablePair<>("filter", serializer.serialize(scenario.clauses(), lang)));
         params.add(new ImmutablePair<>("limit", String.valueOf(scenario.limit())));
         params.add(new ImmutablePair<>("filter-lang", lang.value()));

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceHeaderFilterIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/STACServiceHeaderFilterIT.java
@@ -145,7 +145,7 @@ public class STACServiceHeaderFilterIT extends AbstractSTACServiceTest {
     }
 
     static Stream<Arguments> authorizeColumnFilterCases() {
-        String columnFilter = "geodata:params.job,params.age,params.startdate";
+        String columnFilter = "geodata:params.job,geodata:params.age,geodata:params.startdate";
         return Stream.of(
                 scenarioCases(StacFilterScenario.and(
                         List.of(
@@ -170,7 +170,7 @@ public class STACServiceHeaderFilterIT extends AbstractSTACServiceTest {
     }
 
     static Stream<Arguments> forbiddenCollectionFilterCases() {
-        String columnFilter = "unknowCollection:params.job,params.age,params.startdate";
+        String columnFilter = "unknowCollection:params.job,unknowCollection:params.age,unknowCollection:params.startdate";
         return Stream.of(
                 scenarioCases(StacFilterScenario.and(
                         List.of(

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/FilteringConformanceSuiteIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/FilteringConformanceSuiteIT.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc;
+
+public class FilteringConformanceSuiteIT {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/FilteringConformanceSuiteIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/FilteringConformanceSuiteIT.java
@@ -1,4 +1,37 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc;
 
+import io.arlas.server.tests.stac.conformance.ogc.featuresfilter.FeaturesFilterConformanceIT;
+import io.arlas.server.tests.stac.conformance.ogc.filter.FilterConformanceIT;
+import io.arlas.server.tests.stac.conformance.ogc.queryables.QueryablesConformanceIT;
+import io.arlas.server.tests.stac.conformance.ogc.queryablesparams.QueryablesQueryParametersConformanceIT;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({
+        QueryablesConformanceIT.class,
+        QueryablesQueryParametersConformanceIT.class,
+        FilterConformanceIT.class,
+        FeaturesFilterConformanceIT.class
+})
 public class FilteringConformanceSuiteIT {
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/AbstractOgcApiTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/AbstractOgcApiTest.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc.commons;
+
+public class AbstractOgcApiTest {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/AbstractOgcApiTest.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/AbstractOgcApiTest.java
@@ -1,4 +1,69 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc.commons;
 
-public class AbstractOgcApiTest {
+import io.arlas.server.tests.stac.AbstractSTACServiceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import java.util.Map;
+
+public class AbstractOgcApiTest extends AbstractSTACServiceTest {
+
+    @Override
+    protected String getUrlPath(String collection) {
+        return arlasPath + "stac";
+    }
+
+    public final String apiUri = getUrlPath("");
+
+    protected Response getJson(String path) {
+        return RestAssured
+                .given()
+                .accept("application/json")
+                .when()
+                .get(apiUri+path)
+                .then()
+                .extract()
+                .response();
+    }
+
+    public Response get(String path, String accept) {
+        return RestAssured
+                .given()
+                .accept(accept)
+                .when()
+                .get(apiUri+path)
+                .then()
+                .extract()
+                .response();
+    }
+
+    protected Response get(String path, Map<String, ?> queryParams, String accept) {
+        return RestAssured
+                .given()
+                .queryParams(queryParams)
+                .accept(accept)
+                .when()
+                .get(apiUri+path)
+                .then()
+                .extract()
+                .response();
+    }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CollectionDiscoverySupport.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CollectionDiscoverySupport.java
@@ -1,4 +1,44 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc.commons;
 
-public class CollectionDiscoverySupport {
+import io.restassured.response.Response;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public final class CollectionDiscoverySupport {
+
+    private CollectionDiscoverySupport() {
+    }
+
+    public static void enrichCollectionsMetadata(AbstractOgcApiTest test, List<CollectionFilteringMetadata> metadataList) {
+        for (CollectionFilteringMetadata metadata : metadataList) {
+            Response response = test.get("/collections/" + metadata.getCollectionId(), Map.of(), "application/json");
+            assertEquals(200, response.statusCode());
+
+            List<Double> bbox = response.jsonPath().getList("extent.spatial.bbox[0]", Double.class);
+
+            metadata.setWgs84Bbox(bbox);
+        }
+    }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CollectionDiscoverySupport.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CollectionDiscoverySupport.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc.commons;
+
+public class CollectionDiscoverySupport {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CollectionFilteringMetadata.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CollectionFilteringMetadata.java
@@ -1,0 +1,80 @@
+package io.arlas.server.tests.stac.conformance.ogc.commons;
+import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollectionFilterMetadata {
+
+    private String collectionId;
+    private String itemsPath;
+    private String queryablesUri;
+    private String sampleQueryable;
+    private String spatialQueryable;
+    private boolean additionalProperties = true;
+    private List<Double> wgs84Bbox = new ArrayList<>();
+    private List<String> supportedCrs = new ArrayList<>();
+
+    public String getCollectionId() {
+        return collectionId;
+    }
+
+    public void setCollectionId(String collectionId) {
+        this.collectionId = collectionId;
+    }
+
+    public String getItemsPath() {
+        return itemsPath;
+    }
+
+    public void setItemsPath(String itemsPath) {
+        this.itemsPath = itemsPath;
+    }
+
+    public String getQueryablesUri() {
+        return queryablesUri;
+    }
+
+    public void setQueryablesUri(String queryablesUri) {
+        this.queryablesUri = queryablesUri;
+    }
+
+    public String getSampleQueryable() {
+        return sampleQueryable;
+    }
+
+    public void setSampleQueryable(String sampleQueryable) {
+        this.sampleQueryable = sampleQueryable;
+    }
+
+    public String getSpatialQueryable() {
+        return spatialQueryable;
+    }
+
+    public void setSpatialQueryable(String spatialQueryable) {
+        this.spatialQueryable = spatialQueryable;
+    }
+
+    public boolean isAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    public void setAdditionalProperties(boolean additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+    public List<Double> getWgs84Bbox() {
+        return wgs84Bbox;
+    }
+
+    public void setWgs84Bbox(List<Double> wgs84Bbox) {
+        this.wgs84Bbox = wgs84Bbox == null ? new ArrayList<>() : new ArrayList<>(wgs84Bbox);
+    }
+
+    public List<String> getSupportedCrs() {
+        return supportedCrs;
+    }
+
+    public void setSupportedCrs(List<String> supportedCrs) {
+        this.supportedCrs = supportedCrs == null ? new ArrayList<>() : new ArrayList<>(supportedCrs);
+    }
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CollectionFilteringMetadata.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CollectionFilteringMetadata.java
@@ -1,9 +1,28 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc.commons;
-import java.util.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
-public class CollectionFilterMetadata {
+public class CollectionFilteringMetadata {
 
     private String collectionId;
     private String itemsPath;
@@ -12,7 +31,16 @@ public class CollectionFilterMetadata {
     private String spatialQueryable;
     private boolean additionalProperties = true;
     private List<Double> wgs84Bbox = new ArrayList<>();
-    private List<String> supportedCrs = new ArrayList<>();
+
+    public List<Map<String, Object>> getUnfilteredFeatures() {
+        return unfilteredFeatures;
+    }
+
+    public void setUnfilteredFeatures(List<Map<String, Object>> unfilteredFeatures) {
+        this.unfilteredFeatures = unfilteredFeatures;
+    }
+
+    private List<Map<String, Object>> unfilteredFeatures = new ArrayList<>();
 
     public String getCollectionId() {
         return collectionId;
@@ -68,13 +96,5 @@ public class CollectionFilterMetadata {
 
     public void setWgs84Bbox(List<Double> wgs84Bbox) {
         this.wgs84Bbox = wgs84Bbox == null ? new ArrayList<>() : new ArrayList<>(wgs84Bbox);
-    }
-
-    public List<String> getSupportedCrs() {
-        return supportedCrs;
-    }
-
-    public void setSupportedCrs(List<String> supportedCrs) {
-        this.supportedCrs = supportedCrs == null ? new ArrayList<>() : new ArrayList<>(supportedCrs);
     }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CollectionFilteringMetadata.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CollectionFilteringMetadata.java
@@ -31,6 +31,7 @@ public class CollectionFilteringMetadata {
     private String spatialQueryable;
     private boolean additionalProperties = true;
     private List<Double> wgs84Bbox = new ArrayList<>();
+    private List<Map<String, Object>> unfilteredFeatures = new ArrayList<>();
 
     public List<Map<String, Object>> getUnfilteredFeatures() {
         return unfilteredFeatures;
@@ -39,8 +40,6 @@ public class CollectionFilteringMetadata {
     public void setUnfilteredFeatures(List<Map<String, Object>> unfilteredFeatures) {
         this.unfilteredFeatures = unfilteredFeatures;
     }
-
-    private List<Map<String, Object>> unfilteredFeatures = new ArrayList<>();
 
     public String getCollectionId() {
         return collectionId;

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CqlFilterBuilder.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CqlFilterBuilder.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc.commons;
+
+public class CqlFilterBuilder {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CqlFilterBuilder.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/CqlFilterBuilder.java
@@ -1,4 +1,40 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc.commons;
 
-public class CqlFilterBuilder {
+import java.util.List;
+
+public final class CqlFilterBuilder {
+
+    private CqlFilterBuilder() {}
+
+    public static String validNullCheck(String queryable) {
+        return queryable + " IS NULL";
+    }
+
+    public static String validEqualCheck(String queryable) {
+        return queryable + " = 0";
+    }
+
+    public static String sIntersectsBbox(String spatialQueryable, List<Double> bbox) {
+        return "S_INTERSECTS(" + spatialQueryable + ",BBOX(" +
+                bbox.get(0) + "," + bbox.get(1) + "," + bbox.get(2) + "," + bbox.get(3) + "))";
+    }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/FilteringAssertions.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/FilteringAssertions.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc.commons;
+
+public class FilteringAssertions {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/FilteringAssertions.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/FilteringAssertions.java
@@ -1,4 +1,105 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc.commons;
 
-public class FilteringAssertions {
+import io.restassured.response.Response;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class FilteringAssertions {
+
+    private FilteringAssertions() {}
+
+    public static void assertEveryReturnedResourceMatchesQueryable(Response response, String queryable, Object expectedValue) {
+        List<Map<String, Object>> features = response.jsonPath().getList("features");
+        if (features == null) {
+            return;
+        }
+
+        for (Map<String, Object> feature : features) {
+            Object value = resolveQueryableValue(feature, queryable);
+            assertEquals(
+                    stringify(expectedValue),
+                    stringify(value),
+                    "Feature does not match queryable filter '" + queryable + "'"
+            );
+        }
+    }
+
+    private static Object resolveQueryableValue(Map<String, Object> feature, String queryable) {
+        if (queryable == null || queryable.isBlank()) {
+            return null;
+        }
+
+        Object directValue = feature.get(queryable);
+        if (directValue != null) {
+            return directValue;
+        }
+
+        Object properties = feature.get("properties");
+        if (!(properties instanceof Map<?, ?> propertiesMap)) {
+            return null;
+        }
+
+        return getByDotPath(propertiesMap, queryable);
+    }
+
+    private static Object getByDotPath(Map<?, ?> root, String path) {
+        Object current = root;
+
+        for (String segment : path.split("\\.")) {
+            if (!(current instanceof Map<?, ?> currentMap)) {
+                return null;
+            }
+            current = currentMap.get(segment);
+            if (current == null) {
+                return null;
+            }
+        }
+
+        return current;
+    }
+
+    private static String stringify(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    public static void assertSameFeatureIds(List<Map<String, Object>> expected, List<Map<String, Object>> actual) {
+        Set<String> expectedIds = extractIds(expected);
+        Set<String> actualIds = extractIds(actual);
+        assertEquals(expectedIds, actualIds);
+    }
+
+    public static void assertNoFeatures(Response response) {
+        List<Map<String, Object>> features = response.jsonPath().getList("features");
+        assertTrue(features == null || features.isEmpty());
+    }
+
+    private static Set<String> extractIds(List<Map<String, Object>> features) {
+        if (features == null) return Set.of();
+        return features.stream()
+                .map(f -> Objects.toString(f.get("id"), null))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/QueryablesDiscoverySupport.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/QueryablesDiscoverySupport.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc.commons;
+
+public class QueryablesDiscoverySupport {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/QueryablesDiscoverySupport.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/QueryablesDiscoverySupport.java
@@ -1,4 +1,132 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc.commons;
 
-public class QueryablesDiscoverySupport {
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.response.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class QueryablesDiscoverySupport {
+    private static final String REL = "http://www.opengis.net/def/rel/ogc/1.0/queryables";
+    private static final Pattern LINK_PATTERN = Pattern.compile("<([^>]+)>;\\s*rel=\"([^\"]+)\"");
+
+    private QueryablesDiscoverySupport() {
+    }
+
+    public static List<CollectionFilteringMetadata> loadQueryablesMetadata(AbstractOgcApiTest test, String baseUri) {
+        List<String> collectionIds = loadCollectionIds(test);
+        List<CollectionFilteringMetadata> result = new ArrayList<>();
+
+        for (String collectionId : collectionIds) {
+            CollectionFilteringMetadata metadata = new CollectionFilteringMetadata();
+            metadata.setCollectionId(collectionId);
+            metadata.setItemsPath("/collections/" + collectionId + "/items");
+
+            Response itemsResponse = test.get(metadata.getItemsPath(), Map.of(), "application/json");
+            assertEquals(200, itemsResponse.statusCode());
+
+            String queryablesUri = extractQueryablesLink(itemsResponse);
+            assertNotNull(queryablesUri, "Missing queryables link for " + metadata.getItemsPath());
+            metadata.setQueryablesUri(queryablesUri);
+            String stacBasePath = RestAssured.baseURI + ":" + RestAssured.port + baseUri;
+            String relativeQueryableUri = queryablesUri.replace(stacBasePath, "");
+            Response queryablesResponse = test.get(relativeQueryableUri, Map.of(), "application/schema+json");
+            assertEquals(200, queryablesResponse.statusCode());
+            assertEquals("https://json-schema.org/draft/2020-12/schema", queryablesResponse.jsonPath().getString("$schema"));
+            assertEquals(queryablesUri, queryablesResponse.jsonPath().getString("$id"));
+            assertEquals("object", queryablesResponse.jsonPath().getString("type"));
+
+            Map<String, Object> properties = queryablesResponse.jsonPath().getMap("properties");
+            assertNotNull(properties, "Queryables properties must exist");
+            assertFalse(properties.isEmpty(), "Queryables properties must not be empty");
+
+            String sampleQueryable = null;
+            String spatialQueryable = null;
+
+            for (Map.Entry<String, Object> entry : properties.entrySet()) {
+                if (!(entry.getValue() instanceof Map<?, ?> valueMap)) {
+                    continue;
+                }
+
+                if (sampleQueryable == null && entry.getKey().equals("params.age")) {
+                    sampleQueryable = entry.getKey();
+                }
+                if (spatialQueryable == null  && entry.getKey().equals("geo_params.geometry")) {
+                    spatialQueryable = entry.getKey();
+                }
+            }
+
+            assertNotNull(sampleQueryable, "No sample queryable found for " + collectionId);
+
+            metadata.setSampleQueryable(sampleQueryable);
+            metadata.setSpatialQueryable(spatialQueryable);
+
+            Boolean additionalProperties = queryablesResponse.jsonPath().getBoolean("additionalProperties");
+            metadata.setAdditionalProperties(additionalProperties == null || additionalProperties);
+
+            result.add(metadata);
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<String> loadCollectionIds(AbstractOgcApiTest test) {
+        Response response = test.get("/collections", Map.of(), "application/json");
+        assertEquals(200, response.statusCode());
+        List<Map<String, Object>> collections = response.jsonPath().getList("collections");
+        List<String> ids = new ArrayList<>();
+        if (collections == null) {
+            return ids;
+        }
+        for (Map<String, Object> collection : collections) {
+            Object id = collection.get("id");
+            if (id != null) {
+                ids.add(String.valueOf(id));
+            }
+        }
+        return ids;
+    }
+
+    private static  String extractQueryablesLink(Response response) {
+        Headers headers = response.getHeaders();
+        for (Header h : headers) {
+            if ("Link".equalsIgnoreCase(h.getName())) {
+                Matcher matcher = LINK_PATTERN.matcher(h.getValue());
+                while (matcher.find()) {
+                    String href = matcher.group(1);
+                    String rel = matcher.group(2);
+                    if (REL.equals(rel)) {
+                        return href;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/QueryablesDiscoverySupport.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/commons/QueryablesDiscoverySupport.java
@@ -82,6 +82,7 @@ public final class QueryablesDiscoverySupport {
             }
 
             assertNotNull(sampleQueryable, "No sample queryable found for " + collectionId);
+            assertNotNull(spatialQueryable, "No sample spatial queryable found for " + collectionId);
 
             metadata.setSampleQueryable(sampleQueryable);
             metadata.setSpatialQueryable(spatialQueryable);

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/featuresfilter/FeaturesFilterConformanceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/featuresfilter/FeaturesFilterConformanceIT.java
@@ -1,4 +1,139 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc.featuresfilter;
 
-public class FeatureFilter {
+import io.arlas.server.tests.stac.conformance.ogc.commons.AbstractOgcApiTest;
+import io.arlas.server.tests.stac.conformance.ogc.commons.CollectionDiscoverySupport;
+import io.arlas.server.tests.stac.conformance.ogc.commons.CollectionFilteringMetadata;
+import io.arlas.server.tests.stac.conformance.ogc.commons.CqlFilterBuilder;
+import io.arlas.server.tests.stac.conformance.ogc.commons.FilteringAssertions;
+import io.arlas.server.tests.stac.conformance.ogc.commons.QueryablesDiscoverySupport;
+import io.arlas.server.tests.stac.conformance.ogc.filter.FilterConformanceIT;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class FeaturesFilterConformanceIT extends AbstractOgcApiTest {
+
+    private static final String CONF_FEATURES_FILTER =
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter";
+
+    private List<CollectionFilteringMetadata> metadataList;
+
+    @BeforeAll
+    void setUp() {
+        metadataList = QueryablesDiscoverySupport.loadQueryablesMetadata(this, apiUri);
+        CollectionDiscoverySupport.enrichCollectionsMetadata(this, metadataList);
+    }
+
+    @Test
+    @DisplayName("Scenario: A.4.1 Conformance Test 13 - /conf/features-filter/get-conformance")
+    void getConformance() {
+        Response response = getJson("/conformance");
+        response.then().statusCode(200);
+        assertTrue(response.contentType().contains("application/json"));
+        assertTrue(response.jsonPath().getList("conformsTo", String.class).contains(CONF_FEATURES_FILTER));
+    }
+
+    @Test
+    @DisplayName("Scenario: A.4.2 Conformance Test 14 - /conf/features-filter/get-collections")
+    void getCollections() {
+        Response response = getJson("/collections");
+        response.then().statusCode(200);
+        assertTrue(response.contentType().contains("application/json"));
+        assertTrue(response.jsonPath().getList("collections") != null);
+    }
+
+    @Test
+    @DisplayName("Scenario: A.4.3 Conformance Test 15 - /conf/features-filter/get-collection")
+    void getCollection() {
+        for (CollectionFilteringMetadata metadata : metadataList) {
+            Response response = getJson("/collections/" + metadata.getCollectionId());
+            response.then().statusCode(200);
+            assertTrue(response.contentType().contains("application/json"));
+
+            boolean hasQueryablesLink = response.jsonPath().getList("links").stream().anyMatch(linkObj -> {
+                if (!(linkObj instanceof Map<?, ?> link)) {
+                    return false;
+                }
+                Object rel = link.get("rel");
+                Object href = link.get("href");
+                return "http://www.opengis.net/def/rel/ogc/1.0/queryables".equals(String.valueOf(rel))
+                        && (RestAssured.baseURI + ":" + RestAssured.port + apiUri + "/collections/" + metadata.getCollectionId() + "/queryables").equals(String.valueOf(href));
+            });
+            assertTrue(hasQueryablesLink);
+        }
+    }
+
+    @Test
+    @DisplayName("Scenario: A.4.4 Conformance Test 16 - /conf/features-filter/filter-on-items")
+    void filterOnItems() {
+        FilterConformanceIT filterConformance = new FilterConformanceIT();
+        for (CollectionFilteringMetadata metadata : metadataList) {
+            Response response = filterConformance.get(metadata.getItemsPath(), "application/geo+json");
+            assertTrue(response.statusCode() == 200 || response.statusCode() == 204);
+        }
+    }
+
+    @Test
+    @DisplayName("Scenario: A.4.5 Conformance Test 17 - /conf/features-filter/mixing-expression")
+    void mixingExpression() {
+        for (CollectionFilteringMetadata metadata : metadataList) {
+            if (metadata.getSpatialQueryable() == null || metadata.getWgs84Bbox().size() < 4) {
+                continue;
+            }
+
+            String path = metadata.getItemsPath();
+
+            Response unfiltered = get(path, "application/geo+json");
+            assertTrue(unfiltered.statusCode() == 200 || unfiltered.statusCode() == 204);
+            if (unfiltered.statusCode() == 200) {
+                metadata.setUnfilteredFeatures(unfiltered.jsonPath().getList("features"));
+            }
+
+            List<Double> bbox = metadata.getWgs84Bbox();
+            String filter = CqlFilterBuilder.sIntersectsBbox(metadata.getSpatialQueryable(), bbox);
+
+            Map<String, Object> params = new LinkedHashMap<>();
+            params.put("filter-lang", "cql2-text");
+            params.put("filter", filter);
+            params.put("bbox", bbox.get(0) + "," + bbox.get(1) + "," + bbox.get(2) + "," + bbox.get(3));
+
+            Response response = get(metadata.getItemsPath(), params, "application/geo+json");
+            assertTrue(response.statusCode() == 200 || response.statusCode() == 204);
+            if (response.statusCode() == 200) {
+                FilteringAssertions.assertSameFeatureIds(
+                        metadata.getUnfilteredFeatures(),
+                        response.jsonPath().getList("features")
+                );
+            }
+        }
+    }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/featuresfilter/FeaturesFilterConformanceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/featuresfilter/FeaturesFilterConformanceIT.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc.featuresfilter;
+
+public class FeatureFilter {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/filter/FilterConformanceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/filter/FilterConformanceIT.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc.filter;
+
+public class FilterConformanceIT {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/filter/FilterConformanceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/filter/FilterConformanceIT.java
@@ -23,6 +23,7 @@ import io.arlas.server.tests.stac.conformance.ogc.commons.*;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.*;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -140,18 +141,46 @@ public class FilterConformanceIT extends AbstractOgcApiTest {
     }
 
     @Test
-    @Disabled
-    // ARLAS-Server does not support custom filter-crs param
     @DisplayName("Scenario: A.3.6 Conformance Test 11 - /conf/filter/filter-crs-param")
     void filterCrsParam() {
+        // ARLAS-Server supports only "http://www.opengis.net/def/crs/OGC/1.3/CRS84" for filter-crs param
+        final String supportedCrs = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
+        for (CollectionFilteringMetadata metadata : metadataList) {
+            if (metadata.getSpatialQueryable() == null || metadata.getWgs84Bbox().size() < 4) {
+                continue;
+            }
+            if (metadata.getUnfilteredFeatures() == null || metadata.getUnfilteredFeatures().isEmpty())  {
+                Response unfiltered = get(metadata.getItemsPath(), "application/geo+json");
+                assertTrue(unfiltered.statusCode() == 200 || unfiltered.statusCode() == 204);
+                metadata.setUnfilteredFeatures(
+                        unfiltered.statusCode() == 200 ? unfiltered.jsonPath().getList("features") : List.of()
+                );
+            }
+            List<Double> bbox = metadata.getWgs84Bbox();
+            String filter = CqlFilterBuilder.sIntersectsBbox(metadata.getSpatialQueryable(), bbox);
+            Map<String, Object> okParams = new LinkedHashMap<>();
+            okParams.put("filter-lang", "cql2-text");
+            okParams.put("filter-crs", supportedCrs);
+            okParams.put("filter", filter);
 
+            Response ok = get(metadata.getItemsPath(), okParams, "application/geo+json");
+            assertTrue(ok.statusCode() == 200 || ok.statusCode() == 204);
+
+            if (ok.statusCode() == 200) {
+                FilteringAssertions.assertSameFeatureIds(
+                        metadata.getUnfilteredFeatures(),
+                        ok.jsonPath().getList("features")
+                );
+            }
+
+            Map<String, Object> badParams = new LinkedHashMap<>();
+            badParams.put("filter-lang", "cql2-text");
+            badParams.put("filter-crs", "http://www.opengis.net/def/crs/EPSG/0/4326");
+            badParams.put("filter", filter);
+
+            Response bad = get(metadata.getItemsPath(), badParams, "application/geo+json");
+            assertEquals(400, bad.statusCode());
+        }
     }
 
-    @Test
-    @Disabled
-    // ARLAS-Server does not support custom functions
-    @DisplayName("Scenario: A.3.7 Conformance Test 12 - /conf/filter/get-functions")
-    void getFunctions() {
-
-    }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/filter/FilterConformanceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/filter/FilterConformanceIT.java
@@ -1,4 +1,157 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc.filter;
 
-public class FilterConformanceIT {
+import io.arlas.server.tests.stac.conformance.ogc.commons.*;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class FilterConformanceIT extends AbstractOgcApiTest {
+    private static final String CONF_QUERYABLES = "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables";
+    private List<CollectionFilteringMetadata> metadataList;
+    @BeforeAll
+    void setUp() {
+        metadataList = QueryablesDiscoverySupport.loadQueryablesMetadata(this, apiUri  );
+        CollectionDiscoverySupport.enrichCollectionsMetadata(this, metadataList);
+    }
+
+    @Test
+    @DisplayName("Scenario: A.3.1 Conformance Test 6 - /conf/filter/get-conformance")
+    void getConformanceFilter() {
+        Response response = getJson("/conformance");
+        response.then().statusCode(200);
+        assertTrue(response.contentType().contains("application/json"));
+        assertTrue(response.jsonPath().getList("conformsTo", String.class)
+                .contains(CONF_QUERYABLES));
+    }
+
+    @Test
+    @DisplayName("Scenario: A.3.2 Conformance Test 7 - /conf/filter/filter-param")
+    void filterParam() {
+        for (CollectionFilteringMetadata metadata : metadataList) {
+            String path = metadata.getItemsPath();
+            String queryable = metadata.getSampleQueryable();
+
+            Response unfiltered = get(path, "application/geo+json");
+            assertTrue(unfiltered.statusCode() == 200 || unfiltered.statusCode() == 204);
+            if (unfiltered.statusCode() == 200) {
+                metadata.setUnfilteredFeatures(unfiltered.jsonPath().getList("features"));
+            }
+
+            String validFilter = CqlFilterBuilder.validEqualCheck(queryable);
+            Response filtered = get(path, Map.of("filter-lang", "cql2-text", "filter", validFilter), "application/geo+json");
+            assertTrue(filtered.statusCode() == 200 || filtered.statusCode() == 204);
+            if (filtered.statusCode() == 200) {
+                FilteringAssertions.assertEveryReturnedResourceMatchesQueryable(filtered, queryable, 0);
+            }
+
+            Response invalid = get(path, Map.of("filter-lang", "cql2-text", "filter", "THIS IS NOT A FILTER"), "application/geo+json");
+            assertEquals(400, invalid.statusCode());
+        }
+    }
+
+    @Test
+    @DisplayName("Scenario: A.3.3 Conformance Test 8 - /conf/filter/filter-lang-default")
+    void filterLangDefault() {
+        for (CollectionFilteringMetadata metadata : metadataList) {
+            String queryable = metadata.getSampleQueryable();
+
+            Response filtered = get(metadata.getItemsPath(),
+                    Map.of("filter", CqlFilterBuilder.validNullCheck(queryable)),
+                    "application/geo+json");
+            // ARLAS SERVER does not support is null filter, the conformance test should check 200
+            assertTrue(filtered.statusCode() == 400 );
+
+            Response invalid = get(metadata.getItemsPath(),
+                    Map.of("filter", "THIS IS NOT A FILTER"),
+                    "application/geo+json");
+            assertEquals(400, invalid.statusCode());
+        }
+    }
+
+    @Test
+    @DisplayName("Scenario: A.3.4 Conformance Test 9 - /conf/filter/expression-construction")
+    void expressionConstruction() {
+        for (CollectionFilteringMetadata metadata : metadataList) {
+            if (metadata.isAdditionalProperties()) {
+                continue;
+            }
+
+            String badFilter = CqlFilterBuilder.validEqualCheck("this_is_not_a_queryable");
+            Response response = get(metadata.getItemsPath(),
+                    Map.of("filter-lang", "cql2-text", "filter", badFilter),
+                    "application/geo+json");
+
+            assertEquals(400, response.statusCode());
+        }
+    }
+
+    @Test
+    @DisplayName("Scenario: A.3.5 Conformance Test 10 - /conf/filter/filter-crs-wgs84")
+    void filterCrsWgs84() {
+        for (CollectionFilteringMetadata metadata : metadataList) {
+            if (metadata.getSpatialQueryable() == null || metadata.getWgs84Bbox().size() < 4) {
+                continue;
+            }
+
+            List<Double> bbox = metadata.getWgs84Bbox();
+            String filter = CqlFilterBuilder.sIntersectsBbox(metadata.getSpatialQueryable(), bbox);
+
+            Response response = get(metadata.getItemsPath(),
+                    Map.of("filter-lang", "cql2-text", "filter", filter),
+                    "application/geo+json");
+            assertTrue(response.statusCode() == 200 || response.statusCode() == 204);
+
+            if (response.statusCode() == 200) {
+                FilteringAssertions.assertSameFeatureIds(metadata.getUnfilteredFeatures(), response.jsonPath().getList("features"));
+            }
+
+            String invalidFilter = CqlFilterBuilder.sIntersectsBbox(metadata.getSpatialQueryable(),
+                    List.of(1000000d, 1000000d, 2000000d, 2000000d));
+
+            Response invalid = get(metadata.getItemsPath(),
+                    Map.of("filter-lang", "cql2-text", "filter", invalidFilter),
+                    "application/geo+json");
+            assertEquals(400, invalid.statusCode());
+        }
+    }
+
+    @Test
+    @Disabled
+    // ARLAS-Server does not support custom filter-crs param
+    @DisplayName("Scenario: A.3.6 Conformance Test 11 - /conf/filter/filter-crs-param")
+    void filterCrsParam() {
+
+    }
+
+    @Test
+    @Disabled
+    // ARLAS-Server does not support custom functions
+    @DisplayName("Scenario: A.3.7 Conformance Test 12 - /conf/filter/get-functions")
+    void getFunctions() {
+
+    }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryables/QueryablesConformanceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryables/QueryablesConformanceIT.java
@@ -1,4 +1,64 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
 package io.arlas.server.tests.stac.conformance.ogc.queryables;
 
-public class QueryablesConformanceIT {
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.arlas.server.tests.stac.conformance.ogc.commons.AbstractOgcApiTest;
+import io.arlas.server.tests.stac.conformance.ogc.commons.CollectionFilteringMetadata;
+import io.arlas.server.tests.stac.conformance.ogc.commons.QueryablesDiscoverySupport;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+// Tests from https://docs.ogc.org/is/19-079r2/19-079r2.html conformance
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class QueryablesConformanceIT extends AbstractOgcApiTest {
+    private static final String CONF_QUERYABLES = "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables";
+    private List<CollectionFilteringMetadata> metadataList;
+
+    @BeforeAll
+    void setUp() {
+        metadataList = QueryablesDiscoverySupport.loadQueryablesMetadata(this, apiUri);
+    }
+    @Test
+    @DisplayName("Scenario: A.1.1 Conformance Test 1 - /conf/queryables/get-conformance")
+    void getConformanceQueryables() {
+        Response response = getJson("/conformance");
+        response.then().statusCode(200);
+        assertTrue(response.jsonPath().getList("conformsTo", String.class)
+                .contains(CONF_QUERYABLES));
+    }
+
+    @Test
+    @DisplayName("Scenario: A.1.2 Conformance Test 2 - /conf/queryables/get-queryables-uris")
+    void getQueryablesUris() {
+        assertTrue(metadataList.stream().allMatch(m ->
+                m.getQueryablesUri() != null && !m.getQueryablesUri().isBlank()));
+    }
+
+    @Test
+    @DisplayName("Scenario: A.1.3 Conformance Test 3 - /conf/queryables/get-queryables")
+    void getQueryables() {
+        assertTrue(metadataList.stream().allMatch(m ->
+                m.getSampleQueryable() != null && !m.getSampleQueryable().isBlank()));
+    }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryables/QueryablesConformanceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryables/QueryablesConformanceIT.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc.queryables;
+
+public class QueryablesConformanceIT {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryablesparams/QueryablesQueryParametersConformanceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryablesparams/QueryablesQueryParametersConformanceIT.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc.queryablesparams;
+
+public class QueryablesQueryParametersConformanceIT {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryablesparams/QueryablesQueryParametersConformanceIT.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryablesparams/QueryablesQueryParametersConformanceIT.java
@@ -1,4 +1,80 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc.queryablesparams;
 
-public class QueryablesQueryParametersConformanceIT {
+import io.arlas.server.tests.stac.conformance.ogc.commons.AbstractOgcApiTest;
+import io.arlas.server.tests.stac.conformance.ogc.commons.CollectionFilteringMetadata;
+import io.arlas.server.tests.stac.conformance.ogc.commons.FilteringAssertions;
+import io.arlas.server.tests.stac.conformance.ogc.commons.QueryablesDiscoverySupport;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+// Tests from https://docs.ogc.org/is/19-079r2/19-079r2.html conformance
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class QueryablesQueryParametersConformanceIT extends AbstractOgcApiTest {
+
+    private static final String CONF_QUERYABLES_QUERY = "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables-query-parameters";
+    private List<CollectionFilteringMetadata> metadataList;
+
+    @BeforeAll
+    void setUp() {
+        metadataList = QueryablesDiscoverySupport.loadQueryablesMetadata(this, apiUri);
+    }
+
+    @Test
+    @DisplayName("Scenario: A.2.1 Conformance Test 4 - /conf/queryables-query-parameters/get-conformance")
+    void getConformanceQueryablesQueryParameters() {
+        Response response = getJson("/conformance");
+        response.then().statusCode(200);
+        assertTrue(response.contentType().contains("application/json"));
+        assertTrue(response.jsonPath().getList("conformsTo", String.class)
+                .contains(CONF_QUERYABLES_QUERY));
+    }
+
+
+    @Test
+    @DisplayName("Scenario: A.2.2 Conformance Test 5 - /conf/queryables-query-parameters/query-param")
+    void queryParam() {
+        for (CollectionFilteringMetadata metadata : metadataList) {
+            assertNotNull(metadata.getSampleQueryable());
+            String queryable = metadata.getSampleQueryable();
+            Object validValue = TestValueRegistry.validValue(queryable);
+            Object invalidValue = TestValueRegistry.invalidValue(queryable);
+            if (validValue != null) {
+                Response ok = get(metadata.getItemsPath(), Map.of(queryable, validValue), "application/geo+json");
+                assertEquals(200, ok.statusCode());
+                assertTrue(ok.contentType().contains("application/geo+json"));
+                FilteringAssertions.assertEveryReturnedResourceMatchesQueryable(ok, queryable, validValue);
+            }
+            if (invalidValue != null) {
+                Response ko = get(metadata.getItemsPath(), Map.of(queryable, invalidValue), "application/geo+json");
+                assertEquals(400, ko.statusCode());
+            }
+        }
+    }
 }

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryablesparams/TestValueRegistry.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryablesparams/TestValueRegistry.java
@@ -1,0 +1,4 @@
+package io.arlas.server.tests.stac.conformance.ogc.queryablesparams;
+
+public class TestValueRegistry {
+}

--- a/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryablesparams/TestValueRegistry.java
+++ b/arlas-tests/src/test/java/io/arlas/server/tests/stac/conformance/ogc/queryablesparams/TestValueRegistry.java
@@ -1,4 +1,39 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.arlas.server.tests.stac.conformance.ogc.queryablesparams;
 
-public class TestValueRegistry {
+public final class TestValueRegistry {
+
+    private TestValueRegistry() {}
+
+    public static Object validValue(String queryable) {
+        return switch (queryable) {
+            case "params.age" -> 0;
+            default -> null;
+        };
+    }
+
+    public static Object invalidValue( String queryable) {
+        return switch (queryable) {
+            case "params.age" -> "no number";
+            default -> null;
+        };
+    }
 }

--- a/conf/configuration.yaml
+++ b/conf/configuration.yaml
@@ -167,6 +167,8 @@ arlas_stac:
     - http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2
     - http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions
     - http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions-plus
+    - http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables
+    - http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables-query-parameters
 
 
 arlas_cors:

--- a/scripts/ci/tests-integration-stage.sh
+++ b/scripts/ci/tests-integration-stage.sh
@@ -208,7 +208,7 @@ function test_stac_filter() {
         -e ALIASED_COLLECTION=${ALIASED_COLLECTION} \
         --net arlas_default \
         maven:3.8.5-openjdk-17 \
-        mvn "-Dit.test=STACService*IT,!STACService*EoIT" verify -DskipTests=false -DfailIfNoTests=false -B
+        mvn "-Dit.test=STACService*IT,FilteringConformanceSuiteIT,!STACService*EoIT" verify -DskipTests=false -DfailIfNoTests=false -B
 }
 
 function test_stac_filter_arlas_eo() {
@@ -266,7 +266,7 @@ function test_stac() {
     docker run --rm \
          --net arlas_default \
          --env STAC_URL="${ARLAS_BASE_URI}stac/" \
-         gisaia/ets-ogcapi-features10:1.9.0
+         gisaia/ets-ogcapi-features10:1.9.2
 
     docker run --rm \
         -w /opt/maven \

--- a/stac-api/src/main/java/io/arlas/server/stac/api/ArlasFilterUtils.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/ArlasFilterUtils.java
@@ -21,8 +21,10 @@ package io.arlas.server.stac.api;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.ws.rs.BadRequestException;
 import org.geojson.Polygon;
 import org.geotools.api.filter.*;
 import org.geotools.api.filter.expression.Expression;
@@ -47,7 +49,7 @@ public class ArlasFilterUtils {
     private static final List<String> ROOT_STAC_FIELD = List.of("collection", "catalog", "id", "geometry", "bbox", "centroid", "type");
     private static final List<String> ROOT_STAC_KEY = List.of("properties.", "assets.");
 
-    public static List<String> cql2toArlasFilterList(Filter filter, Boolean isStacModel) throws ArlasException {
+    public static List<String> cql2toArlasFilterList(Filter filter, Boolean isStacModel, Set<String> allowedQueryables) throws ArlasException {
         List<String> filters = new ArrayList<>();
         if (filter == null) {
             return filters;
@@ -56,7 +58,7 @@ public class ArlasFilterUtils {
         if (filter instanceof And) {
             And and = (And) filter;
             for (Filter child : and.getChildren()) {
-                filters.addAll(cql2toArlasFilterList(child, isStacModel));
+                filters.addAll(cql2toArlasFilterList(child, isStacModel, allowedQueryables));
             }
             return filters;
         }
@@ -70,7 +72,7 @@ public class ArlasFilterUtils {
             // Support ONLY the GeoTools form generated from "<>":
             // NOT (property = literal)
             if (child instanceof BinaryComparisonOperator cmp && child instanceof PropertyIsEqualTo) {
-                filters.add(toBinaryComparisonFilter(cmp, "ne", isStacModel));
+                filters.add(toBinaryComparisonFilter(cmp, "ne", isStacModel, allowedQueryables));
                 return filters;
             }
 
@@ -80,28 +82,28 @@ public class ArlasFilterUtils {
         // Comparison operators
         if (filter instanceof BinaryComparisonOperator cmp) {
             if (filter instanceof PropertyIsEqualTo) {
-                filters.add(toBinaryComparisonFilter(cmp, "eq", isStacModel));
+                filters.add(toBinaryComparisonFilter(cmp, "eq", isStacModel, allowedQueryables));
                 return filters;
             } else if (filter instanceof PropertyIsGreaterThanOrEqualTo) {
-                filters.add(toBinaryComparisonFilter(cmp, "gte", isStacModel));
+                filters.add(toBinaryComparisonFilter(cmp, "gte", isStacModel, allowedQueryables));
                 return filters;
             } else if (filter instanceof PropertyIsLessThanOrEqualTo) {
-                filters.add(toBinaryComparisonFilter(cmp, "lte", isStacModel));
+                filters.add(toBinaryComparisonFilter(cmp, "lte", isStacModel, allowedQueryables));
                 return filters;
             } else if (filter instanceof PropertyIsGreaterThan) {
-                filters.add(toBinaryComparisonFilter(cmp, "gt", isStacModel));
+                filters.add(toBinaryComparisonFilter(cmp, "gt", isStacModel, allowedQueryables));
                 return filters;
             } else if (filter instanceof PropertyIsLessThan) {
-                filters.add(toBinaryComparisonFilter(cmp, "lt", isStacModel));
+                filters.add(toBinaryComparisonFilter(cmp, "lt", isStacModel, allowedQueryables));
                 return filters;
             } else if (filter instanceof IsNotEqualToImpl) {
-                filters.add(toBinaryComparisonFilter(cmp, "ne", isStacModel));
+                filters.add(toBinaryComparisonFilter(cmp, "ne", isStacModel, allowedQueryables));
                 return filters;
             }
         }
 
         if (filter instanceof LikeFilterImpl likeFilter) {
-            filters.add(toLikeComparisonFilter(likeFilter, isStacModel));
+            filters.add(toLikeComparisonFilter(likeFilter, isStacModel, allowedQueryables));
             return filters;
         }
 
@@ -114,7 +116,7 @@ public class ArlasFilterUtils {
             if (!(expr instanceof PropertyName)) {
                 throw new InvalidParameterException("Unsupported BETWEEN filter: left-hand expression is not a property");
             }
-            String property = normalizeProperty(((PropertyName) expr).getPropertyName(), isStacModel);
+            String property = normalizeProperty(((PropertyName) expr).getPropertyName(), isStacModel, allowedQueryables);
             String low = literalToString(lower);
             String high = literalToString(upper);
             filters.add(StringUtil.concat(property, ":", "range", ":[", low, "<", high, "]"));
@@ -134,10 +136,10 @@ public class ArlasFilterUtils {
             String property;
             Expression geometryExpr;
             if (e1 instanceof PropertyName p) {
-                property = normalizeProperty(p.getPropertyName(), isStacModel);
+                property = normalizeProperty(p.getPropertyName(), isStacModel, allowedQueryables);
                 geometryExpr = e2;
             } else if (e2 instanceof PropertyName p) {
-                property = normalizeProperty(p.getPropertyName(), isStacModel);
+                property = normalizeProperty(p.getPropertyName(), isStacModel, allowedQueryables);
                 geometryExpr = e1;
             } else {
                 throw new InvalidParameterException("Unsupported spatial filter: no property name found in filter " + filter);
@@ -180,7 +182,7 @@ public class ArlasFilterUtils {
 
     private static String toLikeComparisonFilter(
             LikeFilterImpl cmp,
-            Boolean isStacModel
+            Boolean isStacModel, Set<String> allowedQueryables
     ) throws InvalidParameterException {
         Expression e1 = cmp.getExpression();
         String e2 = cmp.getLiteral();
@@ -189,7 +191,7 @@ public class ArlasFilterUtils {
         String property;
         String value;
         if (e1 instanceof PropertyName p) {
-            property = normalizeProperty(p.getPropertyName(), isStacModel);
+            property = normalizeProperty(p.getPropertyName(), isStacModel, allowedQueryables);
             value = e2;
         } else {
             throw new InvalidParameterException(
@@ -202,7 +204,7 @@ public class ArlasFilterUtils {
     private static String toBinaryComparisonFilter(
             BinaryComparisonOperator cmp,
             String arlasOperator,
-            Boolean isStacModel
+            Boolean isStacModel, Set<String> allowedQueryables
     ) throws InvalidParameterException {
         Expression e1 = cmp.getExpression1();
         Expression e2 = cmp.getExpression2();
@@ -211,10 +213,10 @@ public class ArlasFilterUtils {
         String value;
 
         if (e1 instanceof PropertyName p) {
-            property = normalizeProperty(p.getPropertyName(), isStacModel);
+            property = normalizeProperty(p.getPropertyName(), isStacModel, allowedQueryables);
             value = literalToString(e2);
         } else if (e2 instanceof PropertyName p) {
-            property = normalizeProperty(p.getPropertyName(), isStacModel);
+            property = normalizeProperty(p.getPropertyName(), isStacModel, allowedQueryables);
             value = literalToString(e1);
         } else {
             throw new InvalidParameterException(
@@ -227,14 +229,18 @@ public class ArlasFilterUtils {
 
 
 
-    private static String normalizeProperty(String property, Boolean isStacModel) {
+    private static String normalizeProperty(String property, Boolean isStacModel, Set<String> allowedQueryables) {
         String normalized = property.replace('/', '.');
         if (Boolean.TRUE.equals(isStacModel)) {
-            normalized = normalized.replaceFirst(":", "__");
             if(!ROOT_STAC_FIELD.contains(normalized) && ROOT_STAC_KEY.stream().noneMatch(normalized::startsWith)) {
                 normalized = "properties." + normalized;
             }
         }
+        //Check if property is queryable
+        if (!allowedQueryables.contains(normalized)) {
+            throw new BadRequestException("Unsupported queryable: " + normalized);
+        }
+        normalized = normalized.replaceFirst(":", "__");
         return normalized;
     }
 

--- a/stac-api/src/main/java/io/arlas/server/stac/api/ArlasFilterUtils.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/ArlasFilterUtils.java
@@ -229,7 +229,7 @@ public class ArlasFilterUtils {
 
 
 
-    private static String normalizeProperty(String property, Boolean isStacModel, Set<String> allowedQueryables) {
+    private static String normalizeProperty(String property, Boolean isStacModel, Set<String> allowedQueryables) throws InvalidParameterException {
         String normalized = property.replace('/', '.');
         if (Boolean.TRUE.equals(isStacModel)) {
             if(!ROOT_STAC_FIELD.contains(normalized) && ROOT_STAC_KEY.stream().noneMatch(normalized::startsWith)) {
@@ -238,7 +238,7 @@ public class ArlasFilterUtils {
         }
         //Check if property is queryable
         if (!allowedQueryables.contains(normalized)) {
-            throw new BadRequestException("Unsupported queryable: " + normalized);
+            throw new InvalidParameterException("Unsupported queryable: " + normalized);
         }
         normalized = normalized.replaceFirst(":", "__");
         return normalized;

--- a/stac-api/src/main/java/io/arlas/server/stac/api/QueryablesBuilder.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/QueryablesBuilder.java
@@ -199,7 +199,6 @@ public class QueryablesBuilder {
             case "BOOLEAN":
                 schema.put("type", "boolean");
                 return schema;
-            case "TEXT":
             case "KEYWORD":
                 schema.put("type", "string");
                 return schema;

--- a/stac-api/src/main/java/io/arlas/server/stac/api/QueryablesBuilder.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/QueryablesBuilder.java
@@ -23,9 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Builds a /queryables JSON Schema document from an ARLAS _describe collection response.
@@ -59,7 +57,7 @@ public class QueryablesBuilder {
         boolean isStacModel = describeResponse.path("params").path("is_stac_model").asBoolean(false);
         ObjectNode root = mapper.createObjectNode();
         root.put("$schema", JSON_SCHEMA_2020_12);
-        root.put("$id", baseUrl + "/stac/collections/" + collectionName + "/queryables");
+        root.put("$id", baseUrl + "stac/collections/" + collectionName + "/queryables");
         root.put("type", "object");
         root.put("title", "Queryables for " + collectionName);
         root.put("description", "Queryable names for collection " + collectionName + ".");
@@ -69,6 +67,23 @@ public class QueryablesBuilder {
         ObjectNode targetProperties = (ObjectNode) root.get("properties");
         flattenProperties("", sourceProperties, targetProperties, displayNames, isStacModel);
         return root;
+    }
+
+    // Retrieve all the queryable field in a set from queryable response
+    public static Set<String> getAllowedQueryables(JsonNode queryablesSchema) {
+        if (queryablesSchema == null || queryablesSchema.isMissingNode() || queryablesSchema.isNull()) {
+            return Set.of();
+        }
+        JsonNode properties = queryablesSchema.path("properties");
+        if (!properties.isObject()) {
+            return Set.of();
+        }
+        Set<String> allowedQueryables = new LinkedHashSet<>();
+        Iterator<String> fieldNames = properties.fieldNames();
+        while (fieldNames.hasNext()) {
+            allowedQueryables.add(fieldNames.next());
+        }
+        return allowedQueryables;
     }
 
     /**
@@ -193,6 +208,7 @@ public class QueryablesBuilder {
                 schema.put("format", "date-time");
                 return schema;
             case "LONG":
+            case "INTEGER":
                 schema.put("type", "integer");
                 return schema;
             case "FLOAT":

--- a/stac-api/src/main/java/io/arlas/server/stac/api/StacCollectionsRESTService.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/StacCollectionsRESTService.java
@@ -27,14 +27,17 @@ import io.arlas.commons.exceptions.ArlasException;
 import io.arlas.commons.exceptions.InvalidParameterException;
 import io.arlas.commons.exceptions.NotFoundException;
 import io.arlas.commons.rest.response.Error;
+import io.arlas.commons.utils.StringUtil;
 import io.arlas.server.core.app.Documentation;
 import io.arlas.server.core.app.STACConfiguration;
 import io.arlas.server.core.model.CollectionReference;
+import io.arlas.server.core.model.enumerations.OperatorEnum;
 import io.arlas.server.core.model.response.CollectionReferenceDescription;
 import io.arlas.server.core.services.CollectionReferenceService;
 import io.arlas.server.core.services.ExploreService;
 import io.arlas.server.core.utils.ColumnFilterUtil;
 import io.arlas.server.stac.model.*;
+import io.arlas.server.stac.model.Collection;
 import io.dropwizard.jersey.params.IntParam;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -51,10 +54,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static io.arlas.commons.rest.utils.ServerConstants.*;
 
@@ -66,6 +67,11 @@ public class StacCollectionsRESTService extends StacRESTService {
                                       ExploreService exploreService, String baseUri) {
         super(configuration, arlasRestCacheTimeout, collectionReferenceService, exploreService, baseUri);
     }
+
+    private static final Set<String> RESERVED_QUERY_PARAMS = Set.of(
+            "limit", "bbox", "datetime", "filter", "filter-lang",
+            "sortby", "from", "after", "before"
+    );
 
     @Timed
     @Path("/collections")
@@ -197,22 +203,11 @@ public class StacCollectionsRESTService extends StacRESTService {
                                        @Parameter(hidden = true)
                                        @HeaderParam(value = ARLAS_ORGANISATION) String organisations
     ) throws ArlasException {
-        CollectionReference collectionReference = exploreService.getCollectionReferenceService()
-                .getCollectionReference(collectionId, Optional.ofNullable(organisations));
-        if (collectionReference == null) {
-            throw new NotFoundException(collectionId);
-        }
-        ColumnFilterUtil.assertCollectionsAllowed(Optional.ofNullable(columnFilter), Collections.singletonList(collectionReference));
-        CollectionReferenceDescription collectionReferenceDescription = exploreService.describeCollection(collectionReference, Optional.ofNullable(columnFilter));
-        if (collectionReferenceDescription == null) {
-            throw new NotFoundException("No collection description found for " + collectionId);
-        }
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode config = mapper.valueToTree(collectionReferenceDescription);
-        QueryablesBuilder builder = new QueryablesBuilder();
-        ObjectNode queryables = builder.build(baseUri, config);
+        ObjectNode queryables = getQueryables(collectionId, columnFilter, organisations);
         return cache(Response.ok(queryables),0);
     }
+
+
 
     @Timed
     @Path("/collections/{collectionId}/items")
@@ -335,11 +330,23 @@ public class StacCollectionsRESTService extends StacRESTService {
         CollectionReference collectionReference = collectionReferenceService.getCollectionReference(collectionId, Optional.ofNullable(organisations));
         String dateFilter = getDateFilter(datetime, collectionReference);
         String geoFilter = getGeoFilter(getBboxAsList(bbox), collectionReference);
-
         List<String> f = new ArrayList<>();
         if (dateFilter != null) { f.add(dateFilter); }
         if (geoFilter != null) { f.add(geoFilter); }
 
+        // Dynamic queryable filter
+        // Retrieve all queryables field
+        ObjectNode queryables = getQueryables(collectionId, columnFilter, organisations);
+        Set<String> allowedQueryables = QueryablesBuilder.getAllowedQueryables(queryables);
+        // Retrieve the queryable from url according allowedQueryable
+        Map<String, List<String>> dynamicQueryables = extractDynamicQueryables(uriInfo, allowedQueryables);
+        // Loop on param and add filter
+        for (Map.Entry<String, List<String>> entry : dynamicQueryables.entrySet()) {
+            String queryable = entry.getKey();
+            List<String> values = entry.getValue();
+            f.add(StringUtil.concat(queryable, ":", OperatorEnum.eq.name(), ":",
+                    String.join(",", values)));
+        }
         SearchBody searchBody = new SearchBody()
                 .limit(limit.get())
                 .from(from.get())
@@ -350,7 +357,9 @@ public class StacCollectionsRESTService extends StacRESTService {
                 .filterLang(filterLang);
 
         return cache(Response.ok(getStacFeatureCollection(collectionReference, partitionFilter, Optional.ofNullable(columnFilter),
-                searchBody, f, uriInfo, "GET", true)), 0);
+                searchBody, f, uriInfo, "GET", true, allowedQueryables))
+                .header("Link",
+                "<" + baseUri + "stac/collections/" + collectionId + "/queryables>; rel=\"http://www.opengis.net/def/rel/ogc/1.0/queryables\""), 0);
     }
 
     @Timed
@@ -389,7 +398,7 @@ public class StacCollectionsRESTService extends StacRESTService {
 
         StacFeatureCollection features = getStacFeatureCollection(collectionReference, partitionFilter, Optional.ofNullable(columnFilter), null,
                 java.util.Collections.singletonList(getIdFilter(featureId, collectionReference)),
-                uriInfo, "GET", true);
+                uriInfo, "GET", true, Set.of());
 
         if (features.getFeatures().size() > 0) {
             Item response = features.getFeatures().get(0);
@@ -397,5 +406,40 @@ public class StacCollectionsRESTService extends StacRESTService {
         } else {
             throw new NotFoundException("Item not found");
         }
+    }
+
+    // Retrieve allowed queryable from url param
+    private Map<String, List<String>> extractDynamicQueryables(UriInfo uriInfo, Set<String> allowedQueryables) {
+        Map<String, List<String>> dynamicQueryables = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> entry : uriInfo.getQueryParameters().entrySet()) {
+            String paramName = entry.getKey();
+            if (RESERVED_QUERY_PARAMS.contains(paramName)) {
+                continue;
+            }
+            if (!allowedQueryables.contains(paramName)) {
+                throw new BadRequestException("Unsupported queryable: " + paramName);
+            }
+            dynamicQueryables.put(paramName, new ArrayList<>(entry.getValue()));
+        }
+        return dynamicQueryables;
+    }
+
+    // Build queryable response
+    private ObjectNode getQueryables(String collectionId, String columnFilter, String organisations) throws ArlasException {
+        CollectionReference collectionReference = exploreService.getCollectionReferenceService()
+                .getCollectionReference(collectionId, Optional.ofNullable(organisations));
+        if (collectionReference == null) {
+            throw new NotFoundException(collectionId);
+        }
+        ColumnFilterUtil.assertCollectionsAllowed(Optional.ofNullable(columnFilter), Collections.singletonList(collectionReference));
+        CollectionReferenceDescription collectionReferenceDescription = exploreService.describeCollection(collectionReference, Optional.ofNullable(columnFilter));
+        if (collectionReferenceDescription == null) {
+            throw new NotFoundException("No collection description found for " + collectionId);
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode config = mapper.valueToTree(collectionReferenceDescription);
+        QueryablesBuilder builder = new QueryablesBuilder();
+        ObjectNode queryables = builder.build(baseUri, config);
+        return queryables;
     }
 }

--- a/stac-api/src/main/java/io/arlas/server/stac/api/StacCollectionsRESTService.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/StacCollectionsRESTService.java
@@ -69,7 +69,7 @@ public class StacCollectionsRESTService extends StacRESTService {
     }
 
     private static final Set<String> RESERVED_QUERY_PARAMS = Set.of(
-            "limit", "bbox", "datetime", "filter", "filter-lang",
+            "limit", "bbox", "datetime", "filter", "filter-lang", "filter-crs",
             "sortby", "from", "after", "before"
     );
 
@@ -283,6 +283,7 @@ public class StacCollectionsRESTService extends StacRESTService {
                                         If a feature has multiple temporal properties, it is the decision of the server whether only a single temporal property is used to determine the extent or all relevant temporal properties.""",
                                         style = ParameterStyle.FORM)
                                 @QueryParam(value = "datetime") String datetime,
+
                                 @Parameter(name = "filter", required = false, description = "**Extension:** Filter  A CQL filter expression for filtering items.")
                                     @QueryParam(value = "filter") String filter,
 
@@ -296,6 +297,18 @@ public class StacCollectionsRESTService extends StacRESTService {
                                         schema = @Schema(type = "string", allowableValues = {"cql2-text", "cql2-json"}, defaultValue = "cql2-text")
                                 )
                                     @QueryParam(value = "filter-lang") String filterLang,
+
+                                @Parameter(
+                                        name = "filter-crs",
+                                        required = false,
+                                        description = """
+                                            **Extension:** Filter  The CRS used by spatial literals in the `filter` value.
+                                            Only the following value is supported: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'.""",
+                                        style = ParameterStyle.FORM,
+                                        schema = @Schema(type = "string", allowableValues = { FILTER_CRS_CRS84 },example = FILTER_CRS_CRS84
+                                        )
+                                )
+                                    @QueryParam(value = "filter-crs") String filterCrs,
 
                                 // --------------------------------------------------------
                                 // -----------------------  PAGE   -----------------------
@@ -327,6 +340,9 @@ public class StacCollectionsRESTService extends StacRESTService {
                                 @HeaderParam(value = ARLAS_ORGANISATION) String organisations
                                 ) throws ArlasException {
 
+        if (filterCrs != null && !FILTER_CRS_CRS84.equals(filterCrs)) {
+            throw new InvalidParameterException("Invalid value for query parameter 'filter-crs'. Only '" + FILTER_CRS_CRS84 + "' is supported.");
+        }
         CollectionReference collectionReference = collectionReferenceService.getCollectionReference(collectionId, Optional.ofNullable(organisations));
         String dateFilter = getDateFilter(datetime, collectionReference);
         String geoFilter = getGeoFilter(getBboxAsList(bbox), collectionReference);
@@ -354,6 +370,7 @@ public class StacCollectionsRESTService extends StacRESTService {
                 .after(after)
                 .before(before)
                 .filter(filter)
+                .filterCrs(filterCrs)
                 .filterLang(filterLang);
 
         return cache(Response.ok(getStacFeatureCollection(collectionReference, partitionFilter, Optional.ofNullable(columnFilter),
@@ -409,7 +426,7 @@ public class StacCollectionsRESTService extends StacRESTService {
     }
 
     // Retrieve allowed queryable from url param
-    private Map<String, List<String>> extractDynamicQueryables(UriInfo uriInfo, Set<String> allowedQueryables) {
+    private Map<String, List<String>> extractDynamicQueryables(UriInfo uriInfo, Set<String> allowedQueryables) throws InvalidParameterException {
         Map<String, List<String>> dynamicQueryables = new LinkedHashMap<>();
         for (Map.Entry<String, List<String>> entry : uriInfo.getQueryParameters().entrySet()) {
             String paramName = entry.getKey();
@@ -417,7 +434,7 @@ public class StacCollectionsRESTService extends StacRESTService {
                 continue;
             }
             if (!allowedQueryables.contains(paramName)) {
-                throw new BadRequestException("Unsupported queryable: " + paramName);
+                throw new InvalidParameterException("Unsupported queryable: " + paramName);
             }
             dynamicQueryables.put(paramName, new ArrayList<>(entry.getValue()));
         }

--- a/stac-api/src/main/java/io/arlas/server/stac/api/StacRESTService.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/StacRESTService.java
@@ -84,6 +84,7 @@ public abstract class StacRESTService {
     public static final GeoJsonReader reader = new GeoJsonReader();
     public static final ObjectWriter writer = objectMapper.writer();
     public final String baseUri;
+    public final String FILTER_CRS_CRS84 = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
 
     public StacRESTService(STACConfiguration configuration,
                            int arlasRestCacheTimeout,

--- a/stac-api/src/main/java/io/arlas/server/stac/api/StacRESTService.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/StacRESTService.java
@@ -113,6 +113,12 @@ public abstract class StacRESTService {
                 .href(fromUri(new UriInfoWrapper(uriInfo,baseUri).getBaseUri()).path(StacRESTService.class).build().toString());
     }
 
+    protected StacLink getQueryableLink(UriInfo uriInfo, String collection) {
+        return new StacLink().rel("http://www.opengis.net/def/rel/ogc/1.0/queryables").type("application/schema+json\"")
+                .href(fromUri(new UriInfoWrapper(uriInfo,baseUri).getBaseUri()).path(StacRESTService.class)
+                        .path("/collections/" + collection +"/queryables").build().toString());
+    }
+
     protected StacLink getSelfLink(UriInfo uriInfo) {
         return new StacLink().rel("self").type(MediaType.APPLICATION_JSON)
                 .href(uriInfo.getRequestUriBuilder().build().toString());
@@ -156,6 +162,7 @@ public abstract class StacRESTService {
         List<StacLink> cLinks = new ArrayList<>();
         cLinks.add(getRootLink(uriInfo));
         cLinks.add(getParentLink(uriInfo));
+        cLinks.add(getQueryableLink(uriInfo,collectionReference.collectionName));
         if(collectionReference.params.licenseUrls != null &&  !collectionReference.params.licenseUrls.isEmpty()){
             collectionReference.params.licenseUrls.forEach(l -> cLinks.add(getRawLink(l, "licence")));
         }
@@ -269,12 +276,25 @@ public abstract class StacRESTService {
                                                                  List<String> filter,
                                                                  UriInfo uriInfo,
                                                                  String method,
-                                                                 boolean isOgc) throws ArlasException {
+                                                                 boolean isOgc, Set<String> allowedQueryables) throws ArlasException {
         Search search = new Search();
         List<String> arlasFilterString = new ArrayList<>();
-        if (Objects.nonNull(body) && Objects.nonNull(body.getFilterLang())) {
-            Filter cql2Filter = toFilterWithBboxCcwCorrection(body.getFilter(),body.getFilterLang());
-            arlasFilterString.addAll(ArlasFilterUtils.cql2toArlasFilterList(cql2Filter, collectionReference.params.isStacModel));
+        if (body != null) {
+            if (body.getFilter() != null && body.getFilterLang() == null) {
+                body.setFilterLang("cql2-text");
+            }
+            if (body.getFilterLang() != null) {
+                Filter cql2Filter = toFilterWithBboxCcwCorrection(
+                        body.getFilter(),
+                        body.getFilterLang()
+                );
+                arlasFilterString.addAll(
+                        ArlasFilterUtils.cql2toArlasFilterList(
+                                cql2Filter,
+                                collectionReference.params.isStacModel, allowedQueryables
+                        )
+                );
+            }
         }
         filter.addAll(arlasFilterString);
         search.filter = ParamsParser.getFilter(collectionReference, filter, null, null, true);
@@ -308,7 +328,6 @@ public abstract class StacRESTService {
         List<StacLink> links = new ArrayList<>();
         links.add(getRootLink(uriInfo));
         links.add(getParentLink(uriInfo));
-
         List<Item> items;
         if(collectionReference.params.isStacModel){
             Hits hits = exploreService.search(request, collectionReference, false, uriInfo, method);

--- a/stac-api/src/main/java/io/arlas/server/stac/api/StacSearchRESTService.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/StacSearchRESTService.java
@@ -166,6 +166,18 @@ public class StacSearchRESTService extends StacRESTService {
         )
         @QueryParam(value = "filter-lang") String filterLang,
 
+                                  @Parameter(
+                                          name = "filter-crs",
+                                          required = false,
+                                          description = """
+                                            **Extension:** Filter  The CRS used by spatial literals in the `filter` value.
+                                            Only the following value is supported: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'.""",
+                                          style = ParameterStyle.FORM,
+                                          schema = @Schema(type = "string", allowableValues = { FILTER_CRS_CRS84 },example = FILTER_CRS_CRS84
+                                          )
+                                  )
+                                      @QueryParam(value = "filter-crs") String filterCrs,
+
         @Parameter(name = "sortby", description = """
                         **Optional Extension:** Sort  An array of property names, prefixed by either "+" for ascending or "-" for descending. If no prefix is provided, "+" is assumed.""")
         @QueryParam(value = "sortby") String sortBy,
@@ -194,6 +206,9 @@ public class StacSearchRESTService extends StacRESTService {
             @HeaderParam(value = ARLAS_ORGANISATION) String organisations
 
     ) throws ArlasException, JsonProcessingException {
+        if (filterCrs != null && !FILTER_CRS_CRS84.equals(filterCrs)) {
+            throw new InvalidParameterException("Invalid value for query parameter 'filter-crs'. Only '" + FILTER_CRS_CRS84 + "' is supported.");
+        }
         collections = collections.stream().flatMap(e -> Stream.of(e.split(","))).collect(Collectors.toList());
 
         SearchBody searchBody = new SearchBody().bbox(getBboxAsList(bbox))
@@ -206,6 +221,7 @@ public class StacSearchRESTService extends StacRESTService {
                 .after(after)
                 .before(before)
                 .filter(filter)
+                .filterCrs(filterCrs)
                 .filterLang(filterLang);
 
         if (!StringUtil.isNullOrEmpty(intersects)) {
@@ -246,6 +262,9 @@ public class StacSearchRESTService extends StacRESTService {
                                    @HeaderParam(value = ARLAS_ORGANISATION) String organisations
 
     ) throws ArlasException {
+        if (body.getFilterCrs() != null && !FILTER_CRS_CRS84.equals(body.getFilterCrs())) {
+            throw new InvalidParameterException("Invalid value for parameter 'filter-crs' in post body. Only '" + FILTER_CRS_CRS84 + "' is supported.");
+        }
         return cache(Response.ok(getItems(partitionFilter, Optional.ofNullable(columnFilter), Optional.ofNullable(organisations), uriInfo, body, "POST")), 0);
     }
 
@@ -330,7 +349,7 @@ public class StacSearchRESTService extends StacRESTService {
             );
         }
         CollectionReference collectionReference = collectionReferenceService.getCollectionReference(collections.get(0), organisations);
-        Set<String> allowedQueryables = Set.of();
+        Set<String> allowedQueryables = new HashSet<>();
         if(body.getFilter() != null){
             ObjectNode queryables = getQueryables(columnFilter, organisations, collections.get(0));
             allowedQueryables.addAll(QueryablesBuilder.getAllowedQueryables(queryables));

--- a/stac-api/src/main/java/io/arlas/server/stac/api/StacSearchRESTService.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/api/StacSearchRESTService.java
@@ -59,10 +59,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import org.json.simple.JSONObject;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -214,7 +211,6 @@ public class StacSearchRESTService extends StacRESTService {
         if (!StringUtil.isNullOrEmpty(intersects)) {
             searchBody.setIntersects(GeoUtil.geojsonReader.readValue(intersects));
         }
-
         return cache(Response.ok(getItems(partitionFilter, Optional.ofNullable(columnFilter), Optional.ofNullable(organisations), uriInfo, (SearchBody<String>) searchBody, "GET")), 0);
 
     }
@@ -298,13 +294,18 @@ public class StacSearchRESTService extends StacRESTService {
             );
         }
         String collectionId = collections.get(0);
+        ObjectNode queryables = getQueryables(Optional.ofNullable(columnFilter), Optional.ofNullable(organisations), collectionId);
+        return cache(Response.ok(queryables),0);
+    }
+
+    private ObjectNode getQueryables(Optional<String> columnFilter, Optional<String> organisations, String collectionId) throws ArlasException {
         CollectionReference collectionReference = exploreService.getCollectionReferenceService()
-                .getCollectionReference(collectionId, Optional.ofNullable(organisations));
+                .getCollectionReference(collectionId, organisations);
         if (collectionReference == null) {
             throw new NotFoundException(collectionId);
         }
-        ColumnFilterUtil.assertCollectionsAllowed(Optional.ofNullable(columnFilter), Collections.singletonList(collectionReference));
-        CollectionReferenceDescription collectionReferenceDescription = exploreService.describeCollection(collectionReference, Optional.ofNullable(columnFilter));
+        ColumnFilterUtil.assertCollectionsAllowed(columnFilter, Collections.singletonList(collectionReference));
+        CollectionReferenceDescription collectionReferenceDescription = exploreService.describeCollection(collectionReference, columnFilter);
         if (collectionReferenceDescription == null) {
             throw new NotFoundException("No collection description found for " + collectionId);
         }
@@ -312,9 +313,8 @@ public class StacSearchRESTService extends StacRESTService {
         JsonNode config = mapper.valueToTree(collectionReferenceDescription);
         QueryablesBuilder builder = new QueryablesBuilder();
         ObjectNode queryables = builder.build(baseUri, config);
-        return cache(Response.ok(queryables),0);
+        return queryables;
     }
-
 
 
     // -----------
@@ -330,8 +330,14 @@ public class StacSearchRESTService extends StacRESTService {
             );
         }
         CollectionReference collectionReference = collectionReferenceService.getCollectionReference(collections.get(0), organisations);
+        Set<String> allowedQueryables = Set.of();
+        if(body.getFilter() != null){
+            ObjectNode queryables = getQueryables(columnFilter, organisations, collections.get(0));
+            allowedQueryables.addAll(QueryablesBuilder.getAllowedQueryables(queryables));
+        }
+
         return getStacFeatureCollection(collectionReference, partitionFilter, columnFilter, body,
-                getFilter(collectionReference, body), uriInfo, method, false);
+                getFilter(collectionReference, body), uriInfo, method, false, allowedQueryables);
     }
 
     private List<String> getFilter(CollectionReference collectionReference, SearchBody body) throws ArlasException {

--- a/stac-api/src/main/java/io/arlas/server/stac/model/SearchBody.java
+++ b/stac-api/src/main/java/io/arlas/server/stac/model/SearchBody.java
@@ -55,6 +55,8 @@ public class SearchBody<T>  {
 
   private @Valid String filterLang = null;
 
+  private @Valid String filterCrs = null;
+
   /**
    **/
   public SearchBody<T> datetime(String datetime) {
@@ -93,6 +95,23 @@ public class SearchBody<T>  {
   public void setFilter(String filter) {
     this.filter = filter;
   }
+
+
+    /**
+     **/
+    public SearchBody<T> filterCrs(String filterCrs) {
+        this.filterCrs = filterCrs;
+        return this;
+    }
+
+    @Schema()
+    @JsonProperty("filterCrs")
+    public String getFilterCrs() {
+        return filterCrs;
+    }
+    public void setFilterCrd(String filterCrs) {
+        this.filterCrs = filterCrs;
+    }
 
   @Schema()
   @JsonProperty("datetime")


### PR DESCRIPTION
This PR introduces queryable-aware filtering for STAC endpoints.

### What changed

- `ArlasFilterUtils.cql2toArlasFilterList(...)` now accepts `allowedQueryables` and propagates it through all filter conversion helpers. Property normalization now rejects unsupported queryables. 
- `QueryablesBuilder` now exposes `getAllowedQueryables(JsonNode)` to extract the set of queryable field names from the generated queryables schema. The builder also includes small cleanup changes in schema generation. 
- `StacRESTService` now passes `allowedQueryables` down into filter conversion, so query validation happens during request processing. 
- `StacCollectionsRESTService` now:
  - builds queryables for a collection,
  - extracts dynamic query parameters from the request,
  - rejects unsupported queryable parameters with a `BadRequestException`,
  - passes the allowed queryables to downstream search and filter handling. 
- `StacSearchRESTService` now retrieves queryables for the target collection and forwards the allowed set when building item search filters. 
- `StacRESTService` queryable link generation was adjusted, and `getStacFeatureCollection(...)` now takes the allowed queryables set as an additional argument. 
- CI integration coverage was updated to run `FilteringConformanceSuiteIT` in the STAC filter stage. 
- `configuration.yaml` now advertises the relevant CQL2 and queryables conformance classes. 

### Behavioural impact

- Queries using non-queryable fields are now rejected earlier and more explicitly. 
- Dynamic query parameters on `/collections/{id}/items` are now validated against the collection queryables instead of being accepted blindly. 
- STAC property names are still normalized to internal fields, but only if they belong to the allowed queryables set. 

### Tests

Implemented the [OGC API - Features Part 3 filtering](https://docs.ogc.org/is/19-079r2/19-079r2.html) conformance tests by aligning them with the spec scenarios A.1.1 through A.4.5. The test suite now discovers queryables, collection metadata, and unfiltered feature sets locally per test class, to avoid shared global context and making the tests more independent and reliable.

### Remaining Work to Fully Address Ticket #1055
- Write the documentation
